### PR TITLE
Added dependabot configuration for go modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
 Hi, nice project!         

Since we have a decent amount of go modules I thought it would be useful to enable dependabot to get them updated automatically.       Not everyone appreciates dependabot however, so feel free to close the PR if you prefer.