### PR TITLE
Added github action for go build & test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,23 @@
+name: gha
+on:
+  pull_request:
+  push:
+    tags:
+      - '*'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v4
+      with:
+        go-version: 1.22.x
+    - run: go build ./...
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v4
+      with:
+        go-version: 1.22.x
+    - run: go test ./...


### PR DESCRIPTION
This PR adds a github action to run `go build` and `go test` on Pull Requests
I find that it's handy to know if a PR is going to break something, especially dependabot PRs.    
Feel free to close the PR if you don't agree!