### PR TITLE
Variation In Payload Size For Map Load Runner

### DIFF
--- a/client/defaultConfig.yaml
+++ b/client/defaultConfig.yaml
@@ -171,7 +171,7 @@ queueTests:
       # operations (put and poll) are decoupled in that they run in their own goroutines, so the ability to configure
       # the number of test loops individually for puts and polls directly translates to a higher degree of versatility
       # regarding the client behavior this queue runner can simulate.
-      numRuns: 500
+      numRuns: 10000
       batchSize: 50
       sleeps:
         # Makes a put goroutine sleep once before performing the first put operation.
@@ -203,7 +203,7 @@ queueTests:
     pollConfig:
       # Enable or disable polling goroutine.
       enabled: true
-      numRuns: 500
+      numRuns: 10000
       batchSize: 50
       # Same as for putConfig
       sleeps:
@@ -238,7 +238,7 @@ queueTests:
       prefix: "ht_"
     putConfig:
       enabled: true
-      numRuns: 500
+      numRuns: 10000
       batchSize: 50
       sleeps:
         initialDelay:
@@ -255,7 +255,7 @@ queueTests:
           enableRandomness: true
     pollConfig:
       enabled: true
-      numRuns: 500
+      numRuns: 10000
       batchSize: 50
       sleeps:
         initialDelay:

--- a/client/defaultConfig.yaml
+++ b/client/defaultConfig.yaml
@@ -465,7 +465,7 @@ mapTests:
     numMaps: 10
     # In contrast to the PokedexRunner, whose data set is limited by the number of Pokémon contained in the first-generation Pokédex (151), the LoadRunner can create
     # arbitrarily many entries, and the 'numEntriesPerMap' controls how many entries it will create
-    numEntriesPerMap: 500
+    numEntriesPerMap: 50000
     # The payload for each of the <numEntriesPerMap> entries the LoadRunner creates is a random string, whose size in bytes is controlled by the 'payloadSizeBytes' property
     # (that is to say only one random string is created and will be used as the value in each of the <numEntriesPerMap> key-value pairs in order to
     # reduce the application's memory footprint)

--- a/client/defaultConfig.yaml
+++ b/client/defaultConfig.yaml
@@ -478,7 +478,7 @@ mapTests:
         enabled: true
         lowerBoundaryBytes: 15000
         upperBoundaryBytes: 2000000
-        evaluateNewSizeSteps: 100
+        evaluateNewSizeAfterNumWriteActions: 100
     appendMapIndexToMapName: true
     appendClientIdToMapName: false
     numRuns: 10000

--- a/client/defaultConfig.yaml
+++ b/client/defaultConfig.yaml
@@ -470,6 +470,15 @@ mapTests:
     # (that is to say only one random string is created and will be used as the value in each of the <numEntriesPerMap> key-value pairs in order to
     # reduce the application's memory footprint)
     payloadSizeBytes: 10000000
+    payload:
+      fixedSize:
+        enabled: false
+        sizeBytes: 10000000
+      variableSize:
+        enabled: true
+        lowerBoundaryBytes: 15000
+        upperBoundaryBytes: 2000000
+        evaluateNewSizeSteps: 100
     appendMapIndexToMapName: true
     appendClientIdToMapName: false
     numRuns: 10000

--- a/client/defaultConfig.yaml
+++ b/client/defaultConfig.yaml
@@ -469,7 +469,6 @@ mapTests:
     # The payload for each of the <numEntriesPerMap> entries the LoadRunner creates is a random string, whose size in bytes is controlled by the 'payloadSizeBytes' property
     # (that is to say only one random string is created and will be used as the value in each of the <numEntriesPerMap> key-value pairs in order to
     # reduce the application's memory footprint)
-    payloadSizeBytes: 10000000
     payload:
       fixedSize:
         enabled: false

--- a/client/defaultConfig.yaml
+++ b/client/defaultConfig.yaml
@@ -128,7 +128,6 @@ stateCleaners:
       enabled: true
       thresholdMs: 30000
 
-
 queueTests:
   # 'queueTests.tweets' configures the TweetRunner. The TweetRunner has access to a file containing 500 tweets on
   # Marvel's "Avengers: Endgame" movie. This file is a simplified and shortened version of the original tweet collection,
@@ -466,17 +465,30 @@ mapTests:
     # In contrast to the PokedexRunner, whose data set is limited by the number of Pokémon contained in the first-generation Pokédex (151), the LoadRunner can create
     # arbitrarily many entries, and the 'numEntriesPerMap' controls how many entries it will create
     numEntriesPerMap: 50000
-    # The payload for each of the <numEntriesPerMap> entries the LoadRunner creates is a random string, whose size in bytes is controlled by the 'payloadSizeBytes' property
-    # (that is to say only one random string is created and will be used as the value in each of the <numEntriesPerMap> key-value pairs in order to
-    # reduce the application's memory footprint)
+    # Whereas the PokedexRunner uses a pre-defined data set and hence cannot offer the option for adjusting the payload
+    # size of the keys it writes, the LoadRunner generates a string to be used as the payload, and the properties
+    # below can be used to adjust the manner and size in which this string is generated.
     payload:
       fixedSize:
+        # Whether to use a fixed-size payload. Enabling this will make the LoadRunner generate one string with a
+        # size of 'sizeBytes' and pre-populate all load elements to be used in scope of the LoadRunner's
+        # test loop. Hence, each key-value pair thus written will use the same string payload. Enabling fixed-size
+        # payloads is equivalent to the LoadRunner's functionality in all versions of Hazeltest prior to 0.15.0.
         enabled: false
         sizeBytes: 10000000
       variableSize:
+        # Whether to use variable-size payloads for the LoadRunner's test loop. If enabled, the properties below
+        # are used to configure generating a string-based payload. The size of the generated payload will be within
+        # the closed interval of [lower boundary, upper boundary], as specified by the two corresponding properties below.
         enabled: true
+        # The lower boundary (inclusive) of the size, in bytes, to use for payload generation.
         lowerBoundaryBytes: 15000
+        # The upper boundary (also inclusive) of the size, in bytes, to use for payload generation.
         upperBoundaryBytes: 2000000
+        # The steps after which the size of the payload should be re-evaluated. If set to 100, for example, an evaluated
+        # size within the [lower, upper] boundary will be used for 100 write operations (emphasis on "write" operations;
+        # a read or delete operation will not increase the counter). Set this to 1 if you would like the LoadRunner's test
+        # loop to use a random size within the [lower, upper] boundary for each write operation.
         evaluateNewSizeAfterNumWriteActions: 100
     appendMapIndexToMapName: true
     appendClientIdToMapName: false

--- a/client/defaultConfig.yaml
+++ b/client/defaultConfig.yaml
@@ -482,9 +482,9 @@ mapTests:
         # the closed interval of [lower boundary, upper boundary], as specified by the two corresponding properties below.
         enabled: true
         # The lower boundary (inclusive) of the size, in bytes, to use for payload generation.
-        lowerBoundaryBytes: 15000
+        lowerBoundaryBytes: 1000
         # The upper boundary (also inclusive) of the size, in bytes, to use for payload generation.
-        upperBoundaryBytes: 2000000
+        upperBoundaryBytes: 10000
         # The steps after which the size of the payload should be re-evaluated. If set to 100, for example, an evaluated
         # size within the [lower, upper] boundary will be used for 100 write operations (emphasis on "write" operations;
         # a read or delete operation will not increase the counter). Set this to 1 if you would like the LoadRunner's test

--- a/loadsupport/payloadgenerator.go
+++ b/loadsupport/payloadgenerator.go
@@ -13,7 +13,7 @@ import (
 )
 
 type (
-	payloadConsumingActorTracker struct {
+	PayloadConsumingActorTracker struct {
 		actors sync.Map
 	}
 	PayloadGenerationRequirement struct {
@@ -36,19 +36,19 @@ const (
 
 var (
 	lp                     = logging.GetLogProviderInstance(client.ID())
-	tr                     = payloadConsumingActorTracker{}
+	ActorTracker           = PayloadConsumingActorTracker{}
 	payloadConsumingActors sync.Map
 )
 
 func RegisterPayloadGenerationRequirement(actorBaseName string, r PayloadGenerationRequirement) {
 
-	tr.actors.Store(actorBaseName, r)
+	ActorTracker.actors.Store(actorBaseName, r)
 
 }
 
 func GenerateTrackedRandomStringPayloadWithinBoundary(actorName string) (string, error) {
 
-	r, err := tr.findMatchingRequirement(actorName)
+	r, err := ActorTracker.FindMatchingPayloadGenerationRequirement(actorName)
 
 	if err != nil {
 		lp.LogPayloadGeneratorEvent(fmt.Sprintf("cannot generate payload for actor '%s' because attempt to identify payload generation requirement resulted in error: %v", actorName, err), log.ErrorLevel)
@@ -107,7 +107,7 @@ func GenerateRandomStringPayload(n int) string {
 
 }
 
-func (tr *payloadConsumingActorTracker) findMatchingRequirement(actorName string) (PayloadGenerationRequirement, error) {
+func (tr *PayloadConsumingActorTracker) FindMatchingPayloadGenerationRequirement(actorName string) (PayloadGenerationRequirement, error) {
 
 	lp.LogPayloadGeneratorEvent(fmt.Sprintf("attempting to find previously registered payload generation requirement for actor '%s'", actorName), log.TraceLevel)
 

--- a/loadsupport/payloadgenerator.go
+++ b/loadsupport/payloadgenerator.go
@@ -73,7 +73,7 @@ func GenerateTrackedRandomStringPayloadWithinBoundary(actorName string) (string,
 	if info.numGeneratePayloadInvocations >= steps || freshlyInserted {
 		payloadSize := lower + rand.Intn(upper-lower+1)
 		if !freshlyInserted {
-			lp.LogPayloadGeneratorEvent(fmt.Sprintf("limit of %d invocation/-s for generating payload of same size reached for actor '%s' -- reset counter and determined new payload size of %d bytes", steps, actorName, payloadSize), log.InfoLevel)
+			lp.LogPayloadGeneratorEvent(fmt.Sprintf("limit of %d invocation/-s for generating payload of same size reached for actor '%s' -- reset counter and determined new payload size of %d bytes", steps, actorName, payloadSize), log.TraceLevel)
 		}
 		info.numGeneratePayloadInvocations = 0
 		info.payloadSize = payloadSize

--- a/loadsupport/payloadgenerator.go
+++ b/loadsupport/payloadgenerator.go
@@ -42,12 +42,14 @@ var (
 
 func RegisterPayloadGenerationRequirement(actorBaseName string, r PayloadGenerationRequirement) {
 
+	lp.LogPayloadGeneratorEvent(fmt.Sprintf("registering payload generation requirement for actor '%s': %v", actorBaseName, r), log.TraceLevel)
 	ActorTracker.actors.Store(actorBaseName, r)
 
 }
 
 func GenerateTrackedRandomStringPayloadWithinBoundary(actorName string) (string, error) {
 
+	lp.LogPayloadGeneratorEvent(fmt.Sprintf("generating payload for actor '%s'", actorName), log.TraceLevel)
 	r, err := ActorTracker.FindMatchingPayloadGenerationRequirement(actorName)
 
 	if err != nil {
@@ -69,9 +71,11 @@ func GenerateTrackedRandomStringPayloadWithinBoundary(actorName string) (string,
 
 	steps, lower, upper := r.SameSizeStepsLimit, r.LowerBoundaryBytes, r.UpperBoundaryBytes
 	if info.numGeneratePayloadInvocations >= steps || freshlyInserted {
-		info.numGeneratePayloadInvocations = 0
 		payloadSize := lower + rand.Intn(upper-lower+1)
-		lp.LogPayloadGeneratorEvent(fmt.Sprintf("limit of %d invocations for generating payload of same size reached for actor '%s' -- reset counter and determined new payload size of %d bytes", steps, actorName, payloadSize), log.InfoLevel)
+		if !freshlyInserted {
+			lp.LogPayloadGeneratorEvent(fmt.Sprintf("limit of %d invocation/-s for generating payload of same size reached for actor '%s' -- reset counter and determined new payload size of %d bytes", steps, actorName, payloadSize), log.InfoLevel)
+		}
+		info.numGeneratePayloadInvocations = 0
 		info.payloadSize = payloadSize
 	}
 

--- a/loadsupport/payloadgenerator_test.go
+++ b/loadsupport/payloadgenerator_test.go
@@ -1,0 +1,271 @@
+package loadsupport
+
+import (
+	"sync"
+	"testing"
+)
+
+const (
+	checkMark = "\u2713"
+	ballotX   = "\u2717"
+)
+
+func TestGenerateTrackedRandomStringPayloadWithinBoundary(t *testing.T) {
+
+	t.Log("given an actor name")
+	{
+		t.Log("\twhen no actor with matching name has previously registered a payload generation requirement")
+		{
+			p, err := GenerateTrackedRandomStringPayloadWithinBoundary("awesome-actor")
+
+			msg := "\t\terror must be returned"
+			if err != nil {
+				t.Log(msg, checkMark)
+			} else {
+				t.Fatal(msg, ballotX)
+			}
+
+			msg = "\t\tempty string must be returned"
+			if p == "" {
+				t.Log(msg, checkMark)
+			} else {
+				t.Fatal(msg, ballotX)
+			}
+		}
+
+		t.Log("\twhen actor has previously registered")
+		{
+			t.Log("\t\twhen given actor has not previously invoked payload generation yet")
+			{
+				payloadConsumingActors = sync.Map{}
+
+				actorBaseName := "mapLoadRunner"
+				actorExtendedName := "mapLoadRunner-ht_load-0"
+
+				tr = payloadConsumingActorTracker{}
+
+				registeredRequirement := PayloadGenerationRequirement{
+					LowerBoundaryBytes: 0,
+					UpperBoundaryBytes: 10,
+					SameSizeStepsLimit: 5,
+				}
+				RegisterPayloadGenerationRequirement(actorBaseName, registeredRequirement)
+
+				p, err := GenerateTrackedRandomStringPayloadWithinBoundary(actorExtendedName)
+
+				msg := "\t\t\tno error must be returned"
+				if err == nil {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX)
+				}
+
+				msg = "\t\t\tsize of generated payload must correspond to previously registered payload generation requirement"
+				if len(p) >= registeredRequirement.LowerBoundaryBytes && len(p) <= registeredRequirement.UpperBoundaryBytes {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX)
+				}
+
+				msg = "\t\t\tnew payload generation info value must have been inserted"
+				v, ok := payloadConsumingActors.Load(actorExtendedName)
+				if ok {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX)
+				}
+
+				msg = "\t\t\tnumber of invocations must have been updated in payload generation info for this actor"
+				insertedInfo := v.(PayloadGenerationInfo)
+				if insertedInfo.numGeneratePayloadInvocations == 1 {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX)
+				}
+
+				msg = "\t\t\tpayload generation info must contain size of generated payload"
+				if insertedInfo.payloadSize == len(p) {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX)
+				}
+			}
+
+			t.Log("\t\twhen given actor has previously invoked payload generation")
+			{
+				payloadConsumingActors = sync.Map{}
+
+				actorBaseName := "mapLoadRunner"
+				actorExtendedName := "mapLoadRunner-ht_load-0"
+
+				tr = payloadConsumingActorTracker{}
+
+				registeredRequirement := PayloadGenerationRequirement{
+					LowerBoundaryBytes: 0,
+					UpperBoundaryBytes: 5001,
+					SameSizeStepsLimit: 6,
+				}
+				RegisterPayloadGenerationRequirement(actorBaseName, registeredRequirement)
+
+				previouslyGeneratedPayload := ""
+				for i := 0; i < registeredRequirement.SameSizeStepsLimit+1; i++ {
+					p, err := GenerateTrackedRandomStringPayloadWithinBoundary(actorExtendedName)
+
+					msg := "\t\t\tno error must be returned"
+					if err == nil {
+						t.Log(msg, checkMark, i)
+					} else {
+						t.Fatal(msg, ballotX, i)
+					}
+
+					msg = "\t\t\tnumber of invocations must have been updated in payload generation info for this actor"
+					v, _ := payloadConsumingActors.Load(actorExtendedName)
+
+					payloadGenerationInfo := v.(PayloadGenerationInfo)
+
+					var expectedTrackedNumberOfInvocations int
+					if i < registeredRequirement.SameSizeStepsLimit {
+						expectedTrackedNumberOfInvocations = i + 1
+					} else {
+						expectedTrackedNumberOfInvocations = 1
+					}
+
+					if payloadGenerationInfo.numGeneratePayloadInvocations == expectedTrackedNumberOfInvocations {
+						t.Log(msg, checkMark, i)
+					} else {
+						t.Fatal(msg, ballotX, i, payloadGenerationInfo.numGeneratePayloadInvocations)
+					}
+
+					if i == 0 {
+						msg = "\t\t\tsize of generated payload must correspond to previously registered payload generation requirement"
+						if len(p) > registeredRequirement.LowerBoundaryBytes && len(p) <= registeredRequirement.UpperBoundaryBytes {
+							t.Log(msg, checkMark, i)
+						} else {
+							t.Fatal(msg, ballotX, i)
+						}
+					} else if i < registeredRequirement.SameSizeStepsLimit {
+						t.Log("\t\t\twhen number of invocations is within same size step boundary")
+						{
+							msg = "\t\t\t\tpayload's size must be equal to previous generated payload's size"
+							if len(p) == len(previouslyGeneratedPayload) {
+								t.Log(msg, checkMark, i)
+							} else {
+								t.Fatal(msg, ballotX, i)
+							}
+						}
+					} else {
+						t.Log("\t\t\twhen number of invocations exceeds same size step boundary")
+						{
+							msg = "\t\t\t\tpayload's size must differ from previously generated payload's size"
+							if len(p) != len(previouslyGeneratedPayload) {
+								t.Log(msg, checkMark, i)
+							} else {
+								t.Fatal(msg, ballotX, i)
+							}
+						}
+					}
+
+					previouslyGeneratedPayload = p
+				}
+
+			}
+		}
+
+	}
+
+}
+
+func TestPayloadConsumingActorTracker_findMatchingRequirement(t *testing.T) {
+
+	t.Log("given an actor name")
+	{
+		t.Log("\twhen no actor with corresponding base name has previously registered")
+		{
+			tr = payloadConsumingActorTracker{}
+			// Register a couple of dummy actors
+			for _, a := range []string{"aragorn", "gimli", "legolas"} {
+				RegisterPayloadGenerationRequirement(a, PayloadGenerationRequirement{LowerBoundaryBytes: len(a)})
+			}
+
+			r, err := tr.findMatchingRequirement("super-awesome-actor-name")
+
+			msg := "\t\terror must be returned"
+			if err != nil {
+				t.Log(msg, checkMark)
+			} else {
+				t.Fatal(msg, ballotX)
+			}
+
+			msg = "\t\treturned requirements value must represent empty requirement"
+			emptyRequirement := PayloadGenerationRequirement{}
+			if r == emptyRequirement {
+				t.Log(msg, checkMark)
+			} else {
+				t.Fatal(msg, ballotX)
+			}
+		}
+
+		t.Log("\twhen actor with corresponding base name has previously registered")
+		{
+			tr = payloadConsumingActorTracker{}
+
+			actorBaseName := "mapLoadRunner"
+			registeredRequirement := PayloadGenerationRequirement{
+				LowerBoundaryBytes: 500,
+				UpperBoundaryBytes: 2000,
+				SameSizeStepsLimit: 250,
+			}
+			RegisterPayloadGenerationRequirement(actorBaseName, registeredRequirement)
+
+			RegisterPayloadGenerationRequirement("mapPokedexRunner", PayloadGenerationRequirement{})
+
+			r, err := tr.findMatchingRequirement("mapLoadRunner-ht_load-0")
+
+			msg := "\t\tno error must be returned"
+			if err == nil {
+				t.Log(msg, checkMark)
+			} else {
+				t.Fatal(msg, ballotX)
+			}
+
+			msg = "\t\trequirement corresponding to actor name must be returned"
+			if r == registeredRequirement {
+				t.Log(msg, checkMark)
+			} else {
+				t.Fatal(msg, ballotX, r)
+			}
+
+		}
+	}
+
+}
+
+func TestRegisterPayloadGenerationRequirement(t *testing.T) {
+
+	t.Log("given an actor's base and a payload generation requirement")
+	{
+		t.Log("\twhen actor invokes registration")
+		{
+			actorBaseName := "mapLoadRunner"
+			r := PayloadGenerationRequirement{}
+
+			RegisterPayloadGenerationRequirement(actorBaseName, r)
+
+			registered, ok := tr.actors.Load(actorBaseName)
+			msg := "\t\tactor must have been registered"
+			if ok {
+				t.Log(msg, checkMark)
+			} else {
+				t.Fatal(msg, ballotX)
+			}
+
+			msg = "\t\tpayload generation requirement must have been inserted"
+			if registered == r {
+				t.Log(msg, checkMark)
+			} else {
+				t.Fatal(msg, ballotX)
+			}
+		}
+	}
+
+}

--- a/loadsupport/payloadgenerator_test.go
+++ b/loadsupport/payloadgenerator_test.go
@@ -42,7 +42,7 @@ func TestGenerateTrackedRandomStringPayloadWithinBoundary(t *testing.T) {
 				actorBaseName := "mapLoadRunner"
 				actorExtendedName := "mapLoadRunner-ht_load-0"
 
-				tr = payloadConsumingActorTracker{}
+				ActorTracker = PayloadConsumingActorTracker{}
 
 				registeredRequirement := PayloadGenerationRequirement{
 					LowerBoundaryBytes: 0,
@@ -98,7 +98,7 @@ func TestGenerateTrackedRandomStringPayloadWithinBoundary(t *testing.T) {
 				actorBaseName := "mapLoadRunner"
 				actorExtendedName := "mapLoadRunner-ht_load-0"
 
-				tr = payloadConsumingActorTracker{}
+				ActorTracker = PayloadConsumingActorTracker{}
 
 				registeredRequirement := PayloadGenerationRequirement{
 					LowerBoundaryBytes: 0,
@@ -181,13 +181,13 @@ func TestPayloadConsumingActorTracker_findMatchingRequirement(t *testing.T) {
 	{
 		t.Log("\twhen no actor with corresponding base name has previously registered")
 		{
-			tr = payloadConsumingActorTracker{}
+			ActorTracker = PayloadConsumingActorTracker{}
 			// Register a couple of dummy actors
 			for _, a := range []string{"aragorn", "gimli", "legolas"} {
 				RegisterPayloadGenerationRequirement(a, PayloadGenerationRequirement{LowerBoundaryBytes: len(a)})
 			}
 
-			r, err := tr.findMatchingRequirement("super-awesome-actor-name")
+			r, err := ActorTracker.FindMatchingPayloadGenerationRequirement("super-awesome-actor-name")
 
 			msg := "\t\terror must be returned"
 			if err != nil {
@@ -207,7 +207,7 @@ func TestPayloadConsumingActorTracker_findMatchingRequirement(t *testing.T) {
 
 		t.Log("\twhen actor with corresponding base name has previously registered")
 		{
-			tr = payloadConsumingActorTracker{}
+			ActorTracker = PayloadConsumingActorTracker{}
 
 			actorBaseName := "mapLoadRunner"
 			registeredRequirement := PayloadGenerationRequirement{
@@ -219,7 +219,7 @@ func TestPayloadConsumingActorTracker_findMatchingRequirement(t *testing.T) {
 
 			RegisterPayloadGenerationRequirement("mapPokedexRunner", PayloadGenerationRequirement{})
 
-			r, err := tr.findMatchingRequirement("mapLoadRunner-ht_load-0")
+			r, err := ActorTracker.FindMatchingPayloadGenerationRequirement("mapLoadRunner-ht_load-0")
 
 			msg := "\t\tno error must be returned"
 			if err == nil {
@@ -251,7 +251,7 @@ func TestRegisterPayloadGenerationRequirement(t *testing.T) {
 
 			RegisterPayloadGenerationRequirement(actorBaseName, r)
 
-			registered, ok := tr.actors.Load(actorBaseName)
+			registered, ok := ActorTracker.actors.Load(actorBaseName)
 			msg := "\t\tactor must have been registered"
 			if ok {
 				t.Log(msg, checkMark)

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -19,6 +19,7 @@ const IoEvent = "io event"
 const HzEvent = "hazelcast event"
 const ConfigurationEvent = "configuration event"
 const InternalStateEvent = "internal state event"
+const PayloadGeneratorEvent = "payload generator event"
 
 type LogProvider struct {
 	ClientID uuid.UUID
@@ -69,6 +70,16 @@ func GetLogProviderInstance(clientID uuid.UUID) *LogProvider {
 	}
 
 	return lp
+
+}
+
+func (lp *LogProvider) LogPayloadGeneratorEvent(msg string, level log.Level) {
+
+	fields := log.Fields{
+		"kind": PayloadGeneratorEvent,
+	}
+
+	lp.doLog(msg, fields, level)
 
 }
 

--- a/maps/loadrunner.go
+++ b/maps/loadrunner.go
@@ -125,8 +125,10 @@ func (r *loadRunner) runMapTests(ctx context.Context, hzCluster string, hzMember
 
 	var loadElements []loadElement
 	if useFixedPayload {
+		lp.LogMapRunnerEvent("usage of fixed-size payloads enabled", r.name, log.TraceLevel)
 		loadElements = populateLoadElements(numEntriesPerMap, fixedPayloadSizeBytes)
 	} else if useVariablePayload {
+		lp.LogMapRunnerEvent("usage of variable-size payloads enabled", r.name, log.TraceLevel)
 		// If the user wants variable-sized payloads to be generated, we only generate they keys here, and
 		// let the payload be generated on demand by downstream functionality
 		loadElements = populateLoadElementKeys(numEntriesPerMap)

--- a/maps/loadrunner.go
+++ b/maps/loadrunner.go
@@ -123,7 +123,7 @@ func (r *loadRunner) runMapTests(ctx context.Context, hzCluster string, hzMember
 
 	var loadElements []loadElement
 	if useFixedPayload {
-		loadElements = populateLoadElements()
+		loadElements = populateLoadElements(numEntriesPerMap, fixedPayloadSizeBytes)
 	} else if useVariablePayload {
 		// If the user wants variable-sized payloads to be generated, we only generate they keys here, and
 		// let the payload be generated on demand by downstream functionality
@@ -182,15 +182,15 @@ func populateLoadElementKeys() []loadElement {
 
 }
 
-func populateLoadElements() []loadElement {
+func populateLoadElements(numElementsToPopulate int, payloadSizeBytes int) []loadElement {
 
-	elements := make([]loadElement, numEntriesPerMap)
+	elements := make([]loadElement, numElementsToPopulate)
 	// Depending on the value of 'payloadSizeBytes', this string can get very large, and to generate one
 	// unique string for each map entry will result in high memory consumption of this Hazeltest client.
 	// Thus, we use one random string for each map and reference that string in each load element
-	randomPayload := loadsupport.GenerateRandomStringPayload(fixedPayloadSizeBytes)
+	randomPayload := loadsupport.GenerateRandomStringPayload(payloadSizeBytes)
 
-	for i := 0; i < numEntriesPerMap; i++ {
+	for i := 0; i < numElementsToPopulate; i++ {
 		elements[i] = loadElement{
 			Key:     strconv.Itoa(i),
 			Payload: randomPayload,

--- a/maps/loadrunner.go
+++ b/maps/loadrunner.go
@@ -209,7 +209,7 @@ func populateLoadElements(numElementsToPopulate int, payloadSizeBytes int) []loa
 
 }
 
-func getOrAssemblePayload(mapName string, mapNumber uint16, element any) (string, error) {
+func getOrAssemblePayload(mapName string, mapNumber uint16, element any) (any, error) {
 
 	l := element.(loadElement)
 

--- a/maps/loadrunner.go
+++ b/maps/loadrunner.go
@@ -213,7 +213,10 @@ func getOrAssemblePayload(mapName string, mapNumber uint16, element any) (string
 
 	l := element.(loadElement)
 
-	if useFixedPayload && len(l.Payload) > 0 {
+	if useFixedPayload {
+		if len(l.Payload) == 0 {
+			return "", errors.New("fixed-size payloads have been enabled, but no payload of fixed size was provided in load element")
+		}
 		return l.Payload, nil
 	}
 

--- a/maps/loadrunner.go
+++ b/maps/loadrunner.go
@@ -301,9 +301,11 @@ func populateLoadConfig(runnerKeyPath string, mapBaseName string, a client.Confi
 		}
 	}
 
-	err := validateVariablePayloadSizeBoundaries(variablePayloadSizeLowerBoundaryBytes, variablePayloadSizeUpperBoundaryBytes)
-	if err != nil {
-		return nil, err
+	if useVariablePayload {
+		err := validateVariablePayloadSizeBoundaries(variablePayloadSizeLowerBoundaryBytes, variablePayloadSizeUpperBoundaryBytes)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	configBuilder := runnerConfigBuilder{

--- a/maps/loadrunner.go
+++ b/maps/loadrunner.go
@@ -127,7 +127,7 @@ func (r *loadRunner) runMapTests(ctx context.Context, hzCluster string, hzMember
 	} else if useVariablePayload {
 		// If the user wants variable-sized payloads to be generated, we only generate they keys here, and
 		// let the payload be generated on demand by downstream functionality
-		loadElements = populateLoadElementKeys()
+		loadElements = populateLoadElementKeys(numEntriesPerMap)
 	} else {
 		lp.LogMapRunnerEvent("neither fixed-size nor variable-size load elements have been enabled -- cannot populate load elements", r.name, log.ErrorLevel)
 		return
@@ -170,11 +170,11 @@ func (r *loadRunner) appendState(s runnerState) {
 
 }
 
-func populateLoadElementKeys() []loadElement {
+func populateLoadElementKeys(numKeysToPopulate int) []loadElement {
 
-	elements := make([]loadElement, numEntriesPerMap)
+	elements := make([]loadElement, numKeysToPopulate)
 
-	for i := 0; i < numEntriesPerMap; i++ {
+	for i := 0; i < numKeysToPopulate; i++ {
 		elements[i] = loadElement{Key: strconv.Itoa(i)}
 	}
 

--- a/maps/loadrunner.go
+++ b/maps/loadrunner.go
@@ -239,6 +239,16 @@ func getLoadElementID(element any) string {
 
 }
 
+func validateVariablePayloadSizeBoundaries(lower, upper int) error {
+
+	if lower >= upper {
+		return fmt.Errorf("expected upper boundary to be greater than lower boundary, got %d (upper) and %d (lower)", upper, lower)
+	}
+
+	return nil
+
+}
+
 func populateLoadConfig(runnerKeyPath string, mapBaseName string, a client.ConfigPropertyAssigner) (*runnerConfig, error) {
 
 	var assignmentOps []func() error
@@ -289,6 +299,11 @@ func populateLoadConfig(runnerKeyPath string, mapBaseName string, a client.Confi
 		if err := fn(); err != nil {
 			return nil, err
 		}
+	}
+
+	err := validateVariablePayloadSizeBoundaries(variablePayloadSizeLowerBoundaryBytes, variablePayloadSizeUpperBoundaryBytes)
+	if err != nil {
+		return nil, err
 	}
 
 	configBuilder := runnerConfigBuilder{

--- a/maps/loadrunner_test.go
+++ b/maps/loadrunner_test.go
@@ -349,6 +349,13 @@ func TestRunLoadMapTests(t *testing.T) {
 				t.Fatal(msg, ballotX, l.observations.numRunInvocations)
 			}
 
+			msg = "\t\tget or assemble payload function of test loop execution must be populated"
+			if l.assignedTestLoopExecution.getOrAssemblePayload != nil {
+				t.Log(msg, checkMark)
+			} else {
+				t.Fatal(msg, ballotX)
+			}
+
 		}
 		t.Log("\twhen test loop cannot be initialized")
 		{

--- a/maps/loadrunner_test.go
+++ b/maps/loadrunner_test.go
@@ -35,6 +35,35 @@ func newTestLoadTestLoop() *testLoadTestLoop {
 	}
 }
 
+func TestPopulateLoadElementKeys(t *testing.T) {
+
+	t.Log("given a function to populate only load element keys")
+	{
+		t.Log("\twhen number of entries per map is configured")
+		{
+			msgNumKeys := "\t\tnumber of populated load element keys must be equal to configured number of keys"
+			msgEmptyPayload := "\t\t\tpayload must be empty"
+			for _, numKeys := range []int{0, 3, 12} {
+				loadElementOnlyKeys := populateLoadElementKeys(numKeys)
+				if len(loadElementOnlyKeys) == numKeys {
+					t.Log(msgNumKeys, checkMark, numKeys)
+				} else {
+					t.Fatal(msgNumKeys, ballotX, numKeys)
+				}
+
+				for _, l := range loadElementOnlyKeys {
+					if l.Payload == "" {
+						t.Log(msgEmptyPayload, checkMark, l.Key, numKeys)
+					} else {
+						t.Fatal(msgEmptyPayload, ballotX, l.Key, numKeys)
+					}
+				}
+			}
+		}
+	}
+
+}
+
 func TestPopulateLoadElements(t *testing.T) {
 
 	t.Log("given a function to populate a list of load elements")

--- a/maps/loadrunner_test.go
+++ b/maps/loadrunner_test.go
@@ -697,7 +697,7 @@ func TestGetOrAssemblePayload(t *testing.T) {
 
 				le := loadElement{}
 
-				p, err := getOrAssemblePayload("some-map-name", uint16(0), le)
+				v, err := getOrAssemblePayload("some-map-name", uint16(0), le)
 
 				msg := "\t\terror must be returned"
 				if err != nil {
@@ -706,8 +706,9 @@ func TestGetOrAssemblePayload(t *testing.T) {
 					t.Fatal(msg, ballotX)
 				}
 
+				payload := v.(string)
 				msg = "\t\tempty payload must be returned"
-				if len(p) == 0 {
+				if len(payload) == 0 {
 					t.Log(msg, checkMark)
 				} else {
 					t.Fatal(msg, ballotX)
@@ -749,7 +750,7 @@ func TestGetOrAssemblePayload(t *testing.T) {
 			{
 				loadsupport.ActorTracker = loadsupport.PayloadConsumingActorTracker{}
 
-				p, err := getOrAssemblePayload("map-name", uint16(6), loadElement{})
+				v, err := getOrAssemblePayload("map-name", uint16(6), loadElement{})
 
 				msg := "\t\terror must be returned"
 				if err != nil {
@@ -758,8 +759,9 @@ func TestGetOrAssemblePayload(t *testing.T) {
 					t.Fatal(msg, ballotX)
 				}
 
+				payload := v.(string)
 				msg = "\t\tempty payload must be returned"
-				if len(p) == 0 {
+				if len(payload) == 0 {
 					t.Log(msg, checkMark)
 				} else {
 					t.Fatal(msg, ballotX)
@@ -782,7 +784,7 @@ func TestGetOrAssemblePayload(t *testing.T) {
 					SameSizeStepsLimit: variablePayloadEvaluateNewSizeAfterNumWriteActions,
 				})
 
-				p, err := getOrAssemblePayload("ht_load", uint16(0), loadElement{})
+				v, err := getOrAssemblePayload("ht_load", uint16(0), loadElement{})
 
 				msg := "\t\t\tno error must be returned"
 				if err == nil {
@@ -791,8 +793,9 @@ func TestGetOrAssemblePayload(t *testing.T) {
 					t.Fatal(msg, ballotX, err)
 				}
 
+				payload := v.(string)
 				msg = "\t\t\tpayload must be generated within the specified boundaries"
-				if len(p) >= variablePayloadSizeLowerBoundaryBytes && len(p) <= variablePayloadSizeUpperBoundaryBytes {
+				if len(payload) >= variablePayloadSizeLowerBoundaryBytes && len(payload) <= variablePayloadSizeUpperBoundaryBytes {
 					t.Log(msg, checkMark)
 				} else {
 					t.Fatal(msg, ballotX)
@@ -805,7 +808,7 @@ func TestGetOrAssemblePayload(t *testing.T) {
 			useFixedPayload = false
 			useVariablePayload = false
 
-			p, err := getOrAssemblePayload("some-map-name", uint16(0), loadElement{})
+			v, err := getOrAssemblePayload("some-map-name", uint16(0), loadElement{})
 
 			msg := "\t\terror must be returned"
 			if err != nil {
@@ -814,8 +817,9 @@ func TestGetOrAssemblePayload(t *testing.T) {
 				t.Fatal(msg, ballotX)
 			}
 
+			payload := v.(string)
 			msg = "\t\tempty payload must be returned"
-			if len(p) == 0 {
+			if len(payload) == 0 {
 				t.Log(msg, checkMark)
 			} else {
 				t.Fatal(msg, ballotX)

--- a/maps/loadrunner_test.go
+++ b/maps/loadrunner_test.go
@@ -275,3 +275,107 @@ func TestRunLoadMapTests(t *testing.T) {
 	}
 
 }
+
+func TestPopulateLoadConfig(t *testing.T) {
+
+	t.Log("given set of configuration properties to populate the load config from")
+	{
+		t.Log("\twhen property contains invalid value")
+		{
+			a := &testConfigPropertyAssigner{
+				testConfig: map[string]any{
+					testMapRunnerKeyPath + ".numEntriesPerMap": "i find your lack of faith disturbing",
+				},
+			}
+
+			cfg, err := populateLoadConfig(testMapRunnerKeyPath, testMapBaseName, a)
+
+			msg := "\t\terror must be returned"
+			if err != nil {
+				t.Log(msg, checkMark)
+			} else {
+				t.Fatal(msg, ballotX)
+			}
+
+			msg = "\t\treturned config must be nil"
+			if cfg == nil {
+				t.Log(msg, checkMark)
+			} else {
+				t.Fatal(msg, ballotX)
+			}
+		}
+
+		t.Log("\twhen properties are correct")
+		{
+			tc := assembleTestConfigForTestLoopType(boundary)
+			a := &testConfigPropertyAssigner{testConfig: tc}
+
+			cfg, err := populateLoadConfig(testMapRunnerKeyPath, testMapBaseName, a)
+
+			msg := "\t\tno error must be returned"
+			if err == nil {
+				t.Log(msg, checkMark)
+			} else {
+				t.Fatal(msg, ballotX, err)
+			}
+
+			msg = "\t\tconfig should contain expected values"
+			if valid, detail := configValuesAsExpected(cfg, tc); valid {
+				t.Log(msg, checkMark)
+			} else {
+				t.Fatal(msg, ballotX, detail)
+			}
+
+			msg = "\t\tconfig values specific to load runner must have been correctly populated, too"
+			if numEntriesPerMap == tc[testMapRunnerKeyPath+".numEntriesPerMap"].(int) {
+				t.Log(msg, checkMark)
+			} else {
+				t.Fatal(msg, ballotX)
+			}
+
+			keyPath := testMapRunnerKeyPath + ".payload.fixedSize.enabled"
+			if useFixedPayload == tc[keyPath].(bool) {
+				t.Log(msg, checkMark, keyPath)
+			} else {
+				t.Fatal(msg, ballotX, keyPath)
+			}
+
+			keyPath = testMapRunnerKeyPath + ".payload.fixedSize.sizeBytes"
+			if fixedPayloadSizeBytes == tc[keyPath].(int) {
+				t.Log(msg, checkMark, keyPath)
+			} else {
+				t.Fatal(msg, ballotX, keyPath)
+			}
+
+			keyPath = testMapRunnerKeyPath + ".payload.variableSize.enabled"
+			if useVariablePayload == tc[keyPath].(bool) {
+				t.Log(msg, checkMark, keyPath)
+			} else {
+				t.Fatal(msg, ballotX, keyPath)
+			}
+
+			keyPath = testMapRunnerKeyPath + ".payload.variableSize.lowerBoundaryBytes"
+			if variablePayloadSizeLowerBoundaryBytes == tc[keyPath].(int) {
+				t.Log(msg, checkMark, keyPath)
+			} else {
+				t.Fatal(msg, ballotX, keyPath)
+			}
+
+			keyPath = testMapRunnerKeyPath + ".payload.variableSize.upperBoundaryBytes"
+			if variablePayloadSizeUpperBoundaryBytes == tc[keyPath].(int) {
+				t.Log(msg, checkMark, keyPath)
+			} else {
+				t.Fatal(msg, ballotX, keyPath)
+			}
+
+			keyPath = testMapRunnerKeyPath + ".payload.variableSize.evaluateNewSizeAfterNumWriteActions"
+			if variablePayloadEvaluateNewSizeAfterNumWriteActions == tc[keyPath].(int) {
+				t.Log(msg, checkMark, keyPath)
+			} else {
+				t.Fatal(msg, ballotX, keyPath)
+			}
+
+		}
+	}
+
+}

--- a/maps/loadrunner_test.go
+++ b/maps/loadrunner_test.go
@@ -932,3 +932,38 @@ func TestPopulateLoadConfig(t *testing.T) {
 	}
 
 }
+
+func TestValidateVariablePayloadSizeBoundaries(t *testing.T) {
+
+	t.Log("given a lower and an upper boundary representing the size in bytes of payloads to be generated")
+	{
+		t.Log("\twhen lower is less than upper")
+		{
+			msg := "\t\tno error must be returned"
+			if err := validateVariablePayloadSizeBoundaries(10, 1000); err == nil {
+				t.Log(msg, checkMark)
+			} else {
+				t.Fatal(msg, ballotX)
+			}
+		}
+		t.Log("\twhen lower is equal to upper")
+		{
+			msg := "\t\terror must be returned"
+			if err := validateVariablePayloadSizeBoundaries(10, 10); err != nil {
+				t.Log(msg, checkMark)
+			} else {
+				t.Fatal(msg, ballotX)
+			}
+		}
+		t.Log("\twhen lower is greater than upper")
+		{
+			msg := "\t\terror must be returned"
+			if err := validateVariablePayloadSizeBoundaries(15000, 1000); err != nil {
+				t.Log(msg, checkMark)
+			} else {
+				t.Fatal(msg, ballotX)
+			}
+		}
+	}
+
+}

--- a/maps/loadrunner_test.go
+++ b/maps/loadrunner_test.go
@@ -261,9 +261,11 @@ func TestRunLoadMapTests(t *testing.T) {
 			assigner := testConfigPropertyAssigner{
 				returnError: false,
 				testConfig: map[string]any{
-					"mapTests.load.enabled":                      true,
-					"mapTests.load.testLoop.type":                "batch",
-					"mapTests.load.payload.variableSize.enabled": true,
+					"mapTests.load.enabled":                                 true,
+					"mapTests.load.testLoop.type":                           "batch",
+					"mapTests.load.payload.variableSize.enabled":            true,
+					"mapTests.load.payload.variableSize.lowerBoundaryBytes": 42,
+					"mapTests.load.payload.variableSize.upperBoundaryBytes": 43,
 				},
 			}
 			ch := &testHzClientHandler{}
@@ -928,6 +930,60 @@ func TestPopulateLoadConfig(t *testing.T) {
 				t.Fatal(msg, ballotX, keyPath)
 			}
 
+		}
+
+		t.Log("\twhen lower and upper boundary for variable-size payloads have not been provided")
+		{
+			t.Log("\t\twhen variable-size payloads have been enabled")
+			{
+				tc := assembleTestConfigForTestLoopType(boundary)
+				tc["testMapRunner.payload.variableSize.upperBoundaryBytes"] = 42
+				tc["testMapRunner.payload.variableSize.lowerBoundaryBytes"] = 43
+
+				a := &testConfigPropertyAssigner{testConfig: tc}
+
+				cfg, err := populateLoadConfig(testMapRunnerKeyPath, testMapBaseName, a)
+
+				msg := "\t\t\terror must be returned"
+				if err != nil {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX)
+				}
+
+				msg = "\t\t\tnil config must be returned"
+				if cfg == nil {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX)
+				}
+			}
+			t.Log("\t\twhen variable-size payloads have not been enabled")
+			{
+				tc := assembleTestConfigForTestLoopType(boundary)
+				tc["testMapRunner.payload.fixedSize.enabled"] = true
+				tc["testMapRunner.payload.variableSize.enabled"] = false
+				tc["testMapRunner.payload.variableSize.upperBoundaryBytes"] = 42
+				tc["testMapRunner.payload.variableSize.lowerBoundaryBytes"] = 43
+
+				a := &testConfigPropertyAssigner{testConfig: tc}
+
+				cfg, err := populateLoadConfig(testMapRunnerKeyPath, testMapBaseName, a)
+
+				msg := "\t\t\tno error must be returned"
+				if err == nil {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX)
+				}
+
+				msg = "\t\t\tpopulated config must be returned"
+				if cfg != nil {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX)
+				}
+			}
 		}
 	}
 

--- a/maps/loadrunner_test.go
+++ b/maps/loadrunner_test.go
@@ -35,6 +35,36 @@ func newTestLoadTestLoop() *testLoadTestLoop {
 	}
 }
 
+func TestPopulateLoadElements(t *testing.T) {
+
+	t.Log("given a function to populate a list of load elements")
+	{
+		t.Log("\twhen number of entries per map is configured")
+		{
+			msgNumEntries := "\t\tnumber of load elements in populated list must be equal to configured number of entries per map"
+			msgPayloadSize := "\t\t\tload element must carry payload having configured size"
+			payloadSize := 3
+			for _, numEntries := range []int{0, 6, 21} {
+				loadElements := populateLoadElements(numEntries, payloadSize)
+				if len(loadElements) == numEntries {
+					t.Log(msgNumEntries, checkMark, numEntries)
+				} else {
+					t.Fatal(msgNumEntries, ballotX, numEntries)
+				}
+
+				for _, l := range loadElements {
+					if len(l.Payload) == payloadSize {
+						t.Log(msgPayloadSize, checkMark, numEntries, payloadSize)
+					} else {
+						t.Fatal(msgPayloadSize, ballotX, numEntries, payloadSize)
+					}
+				}
+			}
+		}
+	}
+
+}
+
 func TestInitializeLoadElementTestLoop(t *testing.T) {
 
 	t.Log("given a function to initialize the test loop from the provided loop type")

--- a/maps/maps_test.go
+++ b/maps/maps_test.go
@@ -96,11 +96,11 @@ func (m *testHzMap) Unlock(_ context.Context, _ any) error {
 }
 
 const (
-	checkMark     = "\u2713"
-	ballotX       = "\u2717"
-	runnerKeyPath = "testMapRunner"
-	mapPrefix     = "t_"
-	mapBaseName   = "test"
+	checkMark            = "\u2713"
+	ballotX              = "\u2717"
+	testMapRunnerKeyPath = "testMapRunner"
+	mapPrefix            = "t_"
+	testMapBaseName      = "test"
 )
 
 var (

--- a/maps/pokedexrunner.go
+++ b/maps/pokedexrunner.go
@@ -142,20 +142,21 @@ func (r *pokedexRunner) runMapTests(ctx context.Context, hzCluster string, hzMem
 	lp.LogMapRunnerEvent("initialized hazelcast client", r.name, log.InfoLevel)
 	lp.LogMapRunnerEvent("starting pokedex test loop for maps", r.name, log.InfoLevel)
 
-	lc := &testLoopExecution[pokemon]{
-		id:                  uuid.New(),
-		runnerName:          r.name,
-		source:              r.source,
-		hzClientHandler:     r.hzClientHandler,
-		hzMapStore:          r.hzMapStore,
-		stateCleanerBuilder: &state.DefaultSingleMapCleanerBuilder{},
-		runnerConfig:        config,
-		elements:            p.Pokemon,
-		ctx:                 ctx,
-		getElementIdFunc:    getPokemonID,
+	le := &testLoopExecution[pokemon]{
+		id:                   uuid.New(),
+		runnerName:           r.name,
+		source:               r.source,
+		hzClientHandler:      r.hzClientHandler,
+		hzMapStore:           r.hzMapStore,
+		stateCleanerBuilder:  &state.DefaultSingleMapCleanerBuilder{},
+		runnerConfig:         config,
+		elements:             p.Pokemon,
+		ctx:                  ctx,
+		getElementID:         getPokemonID,
+		getOrAssemblePayload: returnPokemonPayload,
 	}
 
-	r.l.init(lc, &defaultSleeper{}, r.gatherer)
+	r.l.init(le, &defaultSleeper{}, r.gatherer)
 
 	r.appendState(testLoopStart)
 	r.l.run()
@@ -170,6 +171,10 @@ func (r *pokedexRunner) appendState(s runnerState) {
 	r.stateList = append(r.stateList, s)
 	r.gatherer.Updates <- status.Update{Key: string(statusKeyCurrentState), Value: string(s)}
 
+}
+
+func returnPokemonPayload(_ string, _ uint16, element any) (any, error) {
+	return element, nil
 }
 
 func getPokemonID(element any) string {

--- a/maps/runner.go
+++ b/maps/runner.go
@@ -17,7 +17,7 @@ type (
 	runnerLoopType string
 	runner         interface {
 		getSourceName() string
-		runMapTests(ctx context.Context, hzCluster string, hzMembers []string, gatherer *status.Gatherer, storeFunc initMapStoreFunc)
+		runMapTests(ctx context.Context, hzCluster string, hzMembers []string, gatherer *status.Gatherer)
 	}
 	runnerConfig struct {
 		enabled                 bool
@@ -54,9 +54,9 @@ type (
 		HzCluster string
 		HzMembers []string
 	}
-	runnerState      string
-	statusKey        string
-	initMapStoreFunc func(ch hazelcastwrapper.HzClientHandler) hazelcastwrapper.MapStore
+	runnerState     string
+	statusKey       string
+	newMapStoreFunc func(ch hazelcastwrapper.HzClientHandler) hazelcastwrapper.MapStore
 )
 
 type (
@@ -103,9 +103,9 @@ const (
 )
 
 var (
-	runners             []runner
-	lp                  *logging.LogProvider
-	initDefaultMapStore initMapStoreFunc = func(ch hazelcastwrapper.HzClientHandler) hazelcastwrapper.MapStore {
+	runners            []runner
+	lp                 *logging.LogProvider
+	newDefaultMapStore newMapStoreFunc = func(ch hazelcastwrapper.HzClientHandler) hazelcastwrapper.MapStore {
 		return &hazelcastwrapper.DefaultMapStore{Client: ch.GetClient()}
 	}
 )
@@ -554,7 +554,7 @@ func (t *MapTester) TestMaps() {
 
 			api.RegisterStatefulActor(api.MapRunners, rn.getSourceName(), gatherer.AssembleStatusCopy)
 
-			rn.runMapTests(context.TODO(), t.HzCluster, t.HzMembers, gatherer, initDefaultMapStore)
+			rn.runMapTests(context.TODO(), t.HzCluster, t.HzMembers, gatherer)
 		}(i)
 	}
 

--- a/maps/runner_test.go
+++ b/maps/runner_test.go
@@ -60,7 +60,7 @@ var (
 		testMapRunnerKeyPath + ".testLoop.boundary.operationChain.boundaryDefinition.lower.enableRandomness":           true,
 		testMapRunnerKeyPath + ".testLoop.boundary.operationChain.boundaryDefinition.actionTowardsBoundaryProbability": 0.75,
 	}
-	initTestMapStore initMapStoreFunc = func(_ hazelcastwrapper.HzClientHandler) hazelcastwrapper.MapStore {
+	newTestMapStore newMapStoreFunc = func(_ hazelcastwrapper.HzClientHandler) hazelcastwrapper.MapStore {
 		return &testHzMapStore{observations: &testHzMapStoreObservations{}}
 	}
 )

--- a/maps/runner_test.go
+++ b/maps/runner_test.go
@@ -9,49 +9,56 @@ import (
 
 var (
 	baseTestConfig = map[string]any{
-		runnerKeyPath + ".enabled":                                            true,
-		runnerKeyPath + ".numMaps":                                            10,
-		runnerKeyPath + ".appendMapIndexToMapName":                            true,
-		runnerKeyPath + ".appendClientIdToMapName":                            false,
-		runnerKeyPath + ".numRuns":                                            1_000,
-		runnerKeyPath + ".performPreRunClean.enabled":                         true,
-		runnerKeyPath + ".performPreRunClean.errorBehavior":                   "ignore",
-		runnerKeyPath + ".performPreRunClean.cleanAgainThreshold.enabled":     true,
-		runnerKeyPath + ".performPreRunClean.cleanAgainThreshold.thresholdMs": 30000,
-		runnerKeyPath + ".mapPrefix.enabled":                                  true,
-		runnerKeyPath + ".mapPrefix.prefix":                                   mapPrefix,
-		runnerKeyPath + ".sleeps.betweenRuns.enabled":                         true,
-		runnerKeyPath + ".sleeps.betweenRuns.durationMs":                      2_500,
-		runnerKeyPath + ".sleeps.betweenRuns.enableRandomness":                true,
+		testMapRunnerKeyPath + ".enabled":                                                  true,
+		testMapRunnerKeyPath + ".numMaps":                                                  10,
+		testMapRunnerKeyPath + ".appendMapIndexToMapName":                                  true,
+		testMapRunnerKeyPath + ".appendClientIdToMapName":                                  false,
+		testMapRunnerKeyPath + ".numRuns":                                                  1_000,
+		testMapRunnerKeyPath + ".numEntriesPerMap":                                         2_000_000,
+		testMapRunnerKeyPath + ".payload.fixedSize.enabled":                                false,
+		testMapRunnerKeyPath + ".payload.fixedSize.sizeBytes":                              10_000,
+		testMapRunnerKeyPath + ".payload.variableSize.enabled":                             true,
+		testMapRunnerKeyPath + ".payload.variableSize.lowerBoundaryBytes":                  15_000,
+		testMapRunnerKeyPath + ".payload.variableSize.upperBoundaryBytes":                  2000000,
+		testMapRunnerKeyPath + ".payload.variableSize.evaluateNewSizeAfterNumWriteActions": 100,
+		testMapRunnerKeyPath + ".performPreRunClean.enabled":                               true,
+		testMapRunnerKeyPath + ".performPreRunClean.errorBehavior":                         "ignore",
+		testMapRunnerKeyPath + ".performPreRunClean.cleanAgainThreshold.enabled":           true,
+		testMapRunnerKeyPath + ".performPreRunClean.cleanAgainThreshold.thresholdMs":       30000,
+		testMapRunnerKeyPath + ".mapPrefix.enabled":                                        true,
+		testMapRunnerKeyPath + ".mapPrefix.prefix":                                         mapPrefix,
+		testMapRunnerKeyPath + ".sleeps.betweenRuns.enabled":                               true,
+		testMapRunnerKeyPath + ".sleeps.betweenRuns.durationMs":                            2_500,
+		testMapRunnerKeyPath + ".sleeps.betweenRuns.enableRandomness":                      true,
 	}
 	batchTestConfig = map[string]any{
-		runnerKeyPath + ".testLoop.type":                                               "batch",
-		runnerKeyPath + ".testLoop.batch.sleeps.afterBatchAction.enabled":              true,
-		runnerKeyPath + ".testLoop.batch.sleeps.afterBatchAction.durationMs":           50,
-		runnerKeyPath + ".testLoop.batch.sleeps.afterBatchAction.enableRandomness":     false,
-		runnerKeyPath + ".testLoop.batch.sleeps.betweenActionBatches.enabled":          true,
-		runnerKeyPath + ".testLoop.batch.sleeps.betweenActionBatches.durationMs":       2_000,
-		runnerKeyPath + ".testLoop.batch.sleeps.betweenActionBatches.enableRandomness": true,
+		testMapRunnerKeyPath + ".testLoop.type":                                               "batch",
+		testMapRunnerKeyPath + ".testLoop.batch.sleeps.afterBatchAction.enabled":              true,
+		testMapRunnerKeyPath + ".testLoop.batch.sleeps.afterBatchAction.durationMs":           50,
+		testMapRunnerKeyPath + ".testLoop.batch.sleeps.afterBatchAction.enableRandomness":     false,
+		testMapRunnerKeyPath + ".testLoop.batch.sleeps.betweenActionBatches.enabled":          true,
+		testMapRunnerKeyPath + ".testLoop.batch.sleeps.betweenActionBatches.durationMs":       2_000,
+		testMapRunnerKeyPath + ".testLoop.batch.sleeps.betweenActionBatches.enableRandomness": true,
 	}
 	boundaryTestConfig = map[string]any{
-		runnerKeyPath + ".testLoop.type":                                                    "boundary",
-		runnerKeyPath + ".testLoop.boundary.sleeps.betweenOperationChains.enabled":          true,
-		runnerKeyPath + ".testLoop.boundary.sleeps.betweenOperationChains.durationMs":       2_500,
-		runnerKeyPath + ".testLoop.boundary.sleeps.betweenOperationChains.enableRandomness": true,
-		runnerKeyPath + ".testLoop.boundary.sleeps.afterChainAction.enabled":                true,
-		runnerKeyPath + ".testLoop.boundary.sleeps.afterChainAction.durationMs":             100,
-		runnerKeyPath + ".testLoop.boundary.sleeps.afterChainAction.enableRandomness":       true,
-		runnerKeyPath + ".testLoop.boundary.sleeps.uponModeChange.enabled":                  true,
-		runnerKeyPath + ".testLoop.boundary.sleeps.uponModeChange.durationMs":               6_000,
-		runnerKeyPath + ".testLoop.boundary.sleeps.uponModeChange.enableRandomness":         false,
-		runnerKeyPath + ".testLoop.boundary.operationChain.length":                          1_000,
-		runnerKeyPath + ".testLoop.boundary.operationChain.resetAfterChain":                 true,
+		testMapRunnerKeyPath + ".testLoop.type":                                                    "boundary",
+		testMapRunnerKeyPath + ".testLoop.boundary.sleeps.betweenOperationChains.enabled":          true,
+		testMapRunnerKeyPath + ".testLoop.boundary.sleeps.betweenOperationChains.durationMs":       2_500,
+		testMapRunnerKeyPath + ".testLoop.boundary.sleeps.betweenOperationChains.enableRandomness": true,
+		testMapRunnerKeyPath + ".testLoop.boundary.sleeps.afterChainAction.enabled":                true,
+		testMapRunnerKeyPath + ".testLoop.boundary.sleeps.afterChainAction.durationMs":             100,
+		testMapRunnerKeyPath + ".testLoop.boundary.sleeps.afterChainAction.enableRandomness":       true,
+		testMapRunnerKeyPath + ".testLoop.boundary.sleeps.uponModeChange.enabled":                  true,
+		testMapRunnerKeyPath + ".testLoop.boundary.sleeps.uponModeChange.durationMs":               6_000,
+		testMapRunnerKeyPath + ".testLoop.boundary.sleeps.uponModeChange.enableRandomness":         false,
+		testMapRunnerKeyPath + ".testLoop.boundary.operationChain.length":                          1_000,
+		testMapRunnerKeyPath + ".testLoop.boundary.operationChain.resetAfterChain":                 true,
 		// Provide int value to verify config population can handle this case, too
-		runnerKeyPath + ".testLoop.boundary.operationChain.boundaryDefinition.upper.mapFillPercentage":          1,
-		runnerKeyPath + ".testLoop.boundary.operationChain.boundaryDefinition.upper.enableRandomness":           true,
-		runnerKeyPath + ".testLoop.boundary.operationChain.boundaryDefinition.lower.mapFillPercentage":          0.2,
-		runnerKeyPath + ".testLoop.boundary.operationChain.boundaryDefinition.lower.enableRandomness":           true,
-		runnerKeyPath + ".testLoop.boundary.operationChain.boundaryDefinition.actionTowardsBoundaryProbability": 0.75,
+		testMapRunnerKeyPath + ".testLoop.boundary.operationChain.boundaryDefinition.upper.mapFillPercentage":          1,
+		testMapRunnerKeyPath + ".testLoop.boundary.operationChain.boundaryDefinition.upper.enableRandomness":           true,
+		testMapRunnerKeyPath + ".testLoop.boundary.operationChain.boundaryDefinition.lower.mapFillPercentage":          0.2,
+		testMapRunnerKeyPath + ".testLoop.boundary.operationChain.boundaryDefinition.lower.enableRandomness":           true,
+		testMapRunnerKeyPath + ".testLoop.boundary.operationChain.boundaryDefinition.actionTowardsBoundaryProbability": 0.75,
 	}
 	initTestMapStore initMapStoreFunc = func(_ hazelcastwrapper.HzClientHandler) hazelcastwrapper.MapStore {
 		return &testHzMapStore{observations: &testHzMapStoreObservations{}}
@@ -134,7 +141,7 @@ func TestPopulateConfig(t *testing.T) {
 
 	t.Log("given a map runner config containing properties for both a batch and a boundary test loop")
 	{
-		b := runnerConfigBuilder{runnerKeyPath: runnerKeyPath, mapBaseName: mapBaseName}
+		b := runnerConfigBuilder{runnerKeyPath: testMapRunnerKeyPath, mapBaseName: testMapBaseName}
 		t.Log("\twhen property assignment does not yield an error")
 		{
 			for _, lt := range []runnerLoopType{batch, boundary} {
@@ -197,8 +204,8 @@ func TestPopulateConfig(t *testing.T) {
 				}
 
 				testConfig := assembleTestConfigForTestLoopType(boundary)
-				testConfig[runnerKeyPath+".testLoop.boundary.operationChain.boundaryDefinition.upper.mapFillPercentage"] = upper
-				testConfig[runnerKeyPath+".testLoop.boundary.operationChain.boundaryDefinition.lower.mapFillPercentage"] = lower
+				testConfig[testMapRunnerKeyPath+".testLoop.boundary.operationChain.boundaryDefinition.upper.mapFillPercentage"] = upper
+				testConfig[testMapRunnerKeyPath+".testLoop.boundary.operationChain.boundaryDefinition.lower.mapFillPercentage"] = lower
 				assigner := testConfigPropertyAssigner{false, testConfig}
 
 				b.assigner = assigner
@@ -226,87 +233,87 @@ func TestPopulateConfig(t *testing.T) {
 
 func configValuesAsExpected(rc *runnerConfig, expected map[string]any) (bool, string) {
 
-	if rc.mapBaseName != mapBaseName {
+	if rc.mapBaseName != testMapBaseName {
 		return false, "map base name"
 	}
 
-	keyPath := runnerKeyPath + ".enabled"
+	keyPath := testMapRunnerKeyPath + ".enabled"
 	if rc.enabled != expected[keyPath] {
 		return false, keyPath
 	}
 
-	keyPath = runnerKeyPath + ".numMaps"
+	keyPath = testMapRunnerKeyPath + ".numMaps"
 	if rc.numMaps != uint16(expected[keyPath].(int)) {
 		return false, keyPath
 	}
 
-	keyPath = runnerKeyPath + ".numRuns"
+	keyPath = testMapRunnerKeyPath + ".numRuns"
 	if rc.numRuns != uint32(expected[keyPath].(int)) {
 		return false, keyPath
 	}
 
-	keyPath = runnerKeyPath + ".mapPrefix.enabled"
+	keyPath = testMapRunnerKeyPath + ".mapPrefix.enabled"
 	if rc.useMapPrefix != expected[keyPath] {
 		return false, keyPath
 	}
 
-	keyPath = runnerKeyPath + ".mapPrefix.prefix"
+	keyPath = testMapRunnerKeyPath + ".mapPrefix.prefix"
 	if rc.mapPrefix != expected[keyPath] {
 		return false, keyPath
 	}
 
-	keyPath = runnerKeyPath + ".appendMapIndexToMapName"
+	keyPath = testMapRunnerKeyPath + ".appendMapIndexToMapName"
 	if rc.appendMapIndexToMapName != expected[keyPath] {
 		return false, keyPath
 	}
 
-	keyPath = runnerKeyPath + ".appendClientIdToMapName"
+	keyPath = testMapRunnerKeyPath + ".appendClientIdToMapName"
 	if rc.appendClientIdToMapName != expected[keyPath] {
 		return false, keyPath
 	}
 
-	keyPath = runnerKeyPath + ".sleeps.betweenRuns.enabled"
+	keyPath = testMapRunnerKeyPath + ".sleeps.betweenRuns.enabled"
 	if rc.sleepBetweenRuns.enabled != expected[keyPath] {
 		return false, keyPath
 	}
 
-	keyPath = runnerKeyPath + ".sleeps.betweenRuns.durationMs"
+	keyPath = testMapRunnerKeyPath + ".sleeps.betweenRuns.durationMs"
 	if rc.sleepBetweenRuns.durationMs != expected[keyPath] {
 		return false, keyPath
 	}
 
-	keyPath = runnerKeyPath + ".testLoop.type"
+	keyPath = testMapRunnerKeyPath + ".testLoop.type"
 	if string(rc.loopType) != expected[keyPath] {
 		return false, keyPath
 	}
 
 	if rc.loopType == batch {
-		keyPath = runnerKeyPath + ".testLoop.batch.sleeps.afterBatchAction.enabled"
+		keyPath = testMapRunnerKeyPath + ".testLoop.batch.sleeps.afterBatchAction.enabled"
 		if rc.batch.sleepAfterBatchAction.enabled != expected[keyPath] {
 			return false, keyPath
 		}
 
-		keyPath = runnerKeyPath + ".testLoop.batch.sleeps.afterBatchAction.durationMs"
+		keyPath = testMapRunnerKeyPath + ".testLoop.batch.sleeps.afterBatchAction.durationMs"
 		if rc.batch.sleepAfterBatchAction.durationMs != expected[keyPath] {
 			return false, keyPath
 		}
 
-		keyPath = runnerKeyPath + ".testLoop.batch.sleeps.afterBatchAction.enableRandomness"
+		keyPath = testMapRunnerKeyPath + ".testLoop.batch.sleeps.afterBatchAction.enableRandomness"
 		if rc.batch.sleepAfterBatchAction.enableRandomness != expected[keyPath] {
 			return false, keyPath
 		}
 
-		keyPath = runnerKeyPath + ".testLoop.batch.sleeps.betweenActionBatches.enabled"
+		keyPath = testMapRunnerKeyPath + ".testLoop.batch.sleeps.betweenActionBatches.enabled"
 		if rc.batch.sleepBetweenActionBatches.enabled != expected[keyPath] {
 			return false, keyPath
 		}
 
-		keyPath = runnerKeyPath + ".testLoop.batch.sleeps.betweenActionBatches.durationMs"
+		keyPath = testMapRunnerKeyPath + ".testLoop.batch.sleeps.betweenActionBatches.durationMs"
 		if rc.batch.sleepBetweenActionBatches.durationMs != expected[keyPath] {
 			return false, keyPath
 		}
 
-		keyPath = runnerKeyPath + ".testLoop.batch.sleeps.betweenActionBatches.enableRandomness"
+		keyPath = testMapRunnerKeyPath + ".testLoop.batch.sleeps.betweenActionBatches.enableRandomness"
 		if rc.batch.sleepBetweenActionBatches.enableRandomness != expected[keyPath] {
 			return false, keyPath
 		}
@@ -315,78 +322,78 @@ func configValuesAsExpected(rc *runnerConfig, expected map[string]any) (bool, st
 			return false, fmt.Sprintf("boundary test loop config must be nil when batch test loop was configured")
 		}
 	} else if rc.loopType == boundary {
-		keyPath = runnerKeyPath + ".testLoop.boundary.sleeps.betweenOperationChains.enabled"
+		keyPath = testMapRunnerKeyPath + ".testLoop.boundary.sleeps.betweenOperationChains.enabled"
 		if rc.boundary.sleepBetweenOperationChains.enabled != expected[keyPath] {
 			return false, keyPath
 		}
 
-		keyPath = runnerKeyPath + ".testLoop.boundary.sleeps.betweenOperationChains.durationMs"
+		keyPath = testMapRunnerKeyPath + ".testLoop.boundary.sleeps.betweenOperationChains.durationMs"
 		if rc.boundary.sleepBetweenOperationChains.durationMs != expected[keyPath] {
 			return false, keyPath
 		}
 
-		keyPath = runnerKeyPath + ".testLoop.boundary.sleeps.betweenOperationChains.enableRandomness"
+		keyPath = testMapRunnerKeyPath + ".testLoop.boundary.sleeps.betweenOperationChains.enableRandomness"
 		if rc.boundary.sleepBetweenOperationChains.enableRandomness != expected[keyPath] {
 			return false, keyPath
 		}
 
-		keyPath = runnerKeyPath + ".testLoop.boundary.sleeps.afterChainAction.enabled"
+		keyPath = testMapRunnerKeyPath + ".testLoop.boundary.sleeps.afterChainAction.enabled"
 		if rc.boundary.sleepAfterChainAction.enabled != expected[keyPath] {
 			return false, keyPath
 		}
 
-		keyPath = runnerKeyPath + ".testLoop.boundary.sleeps.afterChainAction.durationMs"
+		keyPath = testMapRunnerKeyPath + ".testLoop.boundary.sleeps.afterChainAction.durationMs"
 		if rc.boundary.sleepAfterChainAction.durationMs != expected[keyPath] {
 			return false, keyPath
 		}
 
-		keyPath = runnerKeyPath + ".testLoop.boundary.sleeps.afterChainAction.enableRandomness"
+		keyPath = testMapRunnerKeyPath + ".testLoop.boundary.sleeps.afterChainAction.enableRandomness"
 		if rc.boundary.sleepAfterChainAction.enableRandomness != expected[keyPath] {
 			return false, keyPath
 		}
 
-		keyPath = runnerKeyPath + ".testLoop.boundary.sleeps.uponModeChange.enabled"
+		keyPath = testMapRunnerKeyPath + ".testLoop.boundary.sleeps.uponModeChange.enabled"
 		if rc.boundary.sleepUponModeChange.enabled != expected[keyPath] {
 			return false, keyPath
 		}
 
-		keyPath = runnerKeyPath + ".testLoop.boundary.sleeps.uponModeChange.durationMs"
+		keyPath = testMapRunnerKeyPath + ".testLoop.boundary.sleeps.uponModeChange.durationMs"
 		if rc.boundary.sleepUponModeChange.durationMs != expected[keyPath] {
 			return false, keyPath
 		}
 
-		keyPath = runnerKeyPath + ".testLoop.boundary.sleeps.uponModeChange.enableRandomness"
+		keyPath = testMapRunnerKeyPath + ".testLoop.boundary.sleeps.uponModeChange.enableRandomness"
 		if rc.boundary.sleepUponModeChange.enableRandomness != expected[keyPath] {
 			return false, keyPath
 		}
 
-		keyPath = runnerKeyPath + ".testLoop.boundary.operationChain.resetAfterChain"
+		keyPath = testMapRunnerKeyPath + ".testLoop.boundary.operationChain.resetAfterChain"
 		if rc.boundary.resetAfterChain != expected[keyPath] {
 			return false, keyPath
 		}
 
-		keyPath = runnerKeyPath + ".testLoop.boundary.operationChain.boundaryDefinition.upper.mapFillPercentage"
+		keyPath = testMapRunnerKeyPath + ".testLoop.boundary.operationChain.boundaryDefinition.upper.mapFillPercentage"
 		// int value was provided for this property, so have to perform conversion to int
 		if rc.boundary.upper.mapFillPercentage != float32(expected[keyPath].(int)) {
 			return false, keyPath
 		}
 
-		keyPath = runnerKeyPath + ".testLoop.boundary.operationChain.boundaryDefinition.upper.enableRandomness"
+		keyPath = testMapRunnerKeyPath + ".testLoop.boundary.operationChain.boundaryDefinition.upper.enableRandomness"
 		if rc.boundary.upper.enableRandomness != expected[keyPath] {
 			return false, keyPath
 		}
 
-		keyPath = runnerKeyPath + ".testLoop.boundary.operationChain.boundaryDefinition.lower.mapFillPercentage"
+		keyPath = testMapRunnerKeyPath + ".testLoop.boundary.operationChain.boundaryDefinition.lower.mapFillPercentage"
 		if rc.boundary.lower.mapFillPercentage != float32(expected[keyPath].(float64)) {
 			return false, keyPath
 		}
 
-		keyPath = runnerKeyPath + ".testLoop.boundary.operationChain.boundaryDefinition.lower.enableRandomness"
+		keyPath = testMapRunnerKeyPath + ".testLoop.boundary.operationChain.boundaryDefinition.lower.enableRandomness"
 		if rc.boundary.lower.enableRandomness != expected[keyPath] {
 			return false, keyPath
 		}
 
-		keyPath = runnerKeyPath + ".testLoop.boundary.operationChain.boundaryDefinition.actionTowardsBoundaryProbability"
+		keyPath = testMapRunnerKeyPath + ".testLoop.boundary.operationChain.boundaryDefinition.actionTowardsBoundaryProbability"
 		if rc.boundary.actionTowardsBoundaryProbability != float32(expected[keyPath].(float64)) {
 			return false, keyPath
 		}

--- a/maps/testloop.go
+++ b/maps/testloop.go
@@ -172,66 +172,31 @@ func (l *boundaryTestLoop[t]) run() {
 
 }
 
-func chooseRandomKeyFromCache(cache map[string]struct{}) (string, error) {
-
-	if len(cache) == 0 {
-		return "", errors.New("cannot pick element from empty cache")
-	}
-
-	randomIndex := rand.Intn(len(cache))
-
-	i := 0
-	for k := range cache {
-		if i == randomIndex {
-			return k, nil
-		}
-		i++
-	}
-
-	// Due to the way the random index is initialized and the element is selected, this cannot occur
-	return "", fmt.Errorf("no match found for index %d in cache of size %d", randomIndex, len(cache))
-
-}
-
-func (l *boundaryTestLoop[t]) chooseRandomElementFromSourceData() t {
-
-	randomIndex := rand.Intn(len(l.tle.elements))
-	return l.tle.elements[randomIndex]
-
-}
-
-func (l *boundaryTestLoop[t]) chooseNextMapElement(action mapAction, keysCache map[string]struct{}, mapNumber uint16) (t, error) {
+func (l *boundaryTestLoop[t]) chooseNextMapElement(action mapAction, elementsInserted, elementsAvailableForInsertion map[string]t) (t, error) {
 
 	switch action {
 	case insert:
-		for _, v := range l.tle.elements {
-			key := assembleMapKey(mapNumber, l.tle.getElementID(v))
-			if _, containsKey := keysCache[key]; !containsKey {
-				return v, nil
-			}
+		// Maps do not preserve order in Go, but that's totally fine -- just whatever element from those available
+		// for insertion happens to be the first one right now
+		for _, v := range elementsAvailableForInsertion {
+			return v, nil
 		}
 		// Getting to this point means that the 'insert' action was chosen elsewhere despite the fact
 		// that all elements have already been stored in cache. This case should not occur,
 		// but when it does nonetheless, it is not sufficiently severe to report an error
 		// and abort execution. So, in this case, we simply choose an element from the source data randomly.
-		lp.LogMapRunnerEvent("cache already contains all elements of data source, so cannot pick element not yet contained -- choosing one at random", l.tle.runnerName, log.WarnLevel)
-		return l.chooseRandomElementFromSourceData(), nil
+		lp.LogMapRunnerEvent("cache already contains all elements of data source, so cannot pick element not yet contained -- using first element from runner source data", l.tle.runnerName, log.WarnLevel)
+		return l.tle.elements[0], nil
 	case read, remove:
-		keyFromCache, err := chooseRandomKeyFromCache(keysCache)
-		if err != nil {
-			msg := fmt.Sprintf("choosing next map element for map action '%s' unsuccessful: %s", action, err.Error())
-			lp.LogMapRunnerEvent(msg, l.tle.runnerName, log.ErrorLevel)
-			return l.tle.elements[0], fmt.Errorf(msg)
+		if len(elementsInserted) == 0 {
+			return l.tle.elements[0], errors.New("no elements have been previously inserted, so cannot choose element to read or remove")
 		}
-		for _, v := range l.tle.elements {
-			keyFromSourceData := assembleMapKey(mapNumber, l.tle.getElementID(v))
-			if keyFromSourceData == keyFromCache {
-				return v, nil
-			}
+		// Similar to above, the fact that maps do not preserve order doesn't concern us
+		for _, v := range elementsInserted {
+			return v, nil
 		}
-		msg := fmt.Sprintf("key '%s' from local cache had no match in source data -- cache may have been populated incorrectly", keyFromCache)
-		lp.LogMapRunnerEvent(msg, l.tle.runnerName, log.ErrorLevel)
-		return l.tle.elements[0], errors.New(msg)
+		// This case cannot occur
+		return l.tle.elements[0], nil
 	default:
 		msg := fmt.Sprintf("no such map action: %s", action)
 		lp.LogMapRunnerEvent(msg, l.tle.runnerName, log.ErrorLevel)
@@ -240,9 +205,9 @@ func (l *boundaryTestLoop[t]) chooseNextMapElement(action mapAction, keysCache m
 
 }
 
-func assemblePredicate(clientID uuid.UUID, mapNumber uint16) predicate.Predicate {
+func assemblePredicate(clientID uuid.UUID, mapName string, mapNumber uint16) predicate.Predicate {
 
-	return predicate.SQL(fmt.Sprintf("__key like %s-%d%%", clientID, mapNumber))
+	return predicate.SQL(fmt.Sprintf("__key like %s-%s-%d%%", clientID, mapName, mapNumber))
 
 }
 
@@ -252,7 +217,8 @@ func (l *boundaryTestLoop[t]) runForMap(m hazelcastwrapper.Map, mapName string, 
 
 	mc := &modeCache{}
 	ac := &actionCache{}
-	keysCache := make(map[string]struct{})
+	elementsInserted := make(map[string]t)
+	elementsAvailableForInsertion := l.populateElementsAvailableForInsertion(mapName, mapNumber)
 
 	for i := uint32(0); i < l.tle.runnerConfig.numRuns; i++ {
 
@@ -262,7 +228,7 @@ func (l *boundaryTestLoop[t]) runForMap(m hazelcastwrapper.Map, mapName string, 
 			lp.LogMapRunnerEvent(fmt.Sprintf("finished %d of %d runs for map %s in map goroutine %d", i, l.tle.runnerConfig.numRuns, mapName, mapNumber), l.tle.runnerName, log.InfoLevel)
 		}
 
-		if err := l.runOperationChain(i, m, mc, ac, mapName, mapNumber, keysCache); err != nil {
+		if err := l.runOperationChain(i, m, mc, ac, mapName, mapNumber, elementsInserted, elementsAvailableForInsertion); err != nil {
 			lp.LogMapRunnerEvent(fmt.Sprintf("running operation chain unsuccessful in map run %d on map '%s' in goroutine %d -- retrying in next run", i, mapName, mapNumber), l.tle.runnerName, log.WarnLevel)
 		} else {
 			lp.LogMapRunnerEvent(fmt.Sprintf("successfully finished operation chain for map '%s' in goroutine %d in map run %d", mapName, mapNumber, i), l.tle.runnerName, log.InfoLevel)
@@ -270,7 +236,7 @@ func (l *boundaryTestLoop[t]) runForMap(m hazelcastwrapper.Map, mapName string, 
 
 		if l.tle.runnerConfig.boundary.resetAfterChain {
 			lp.LogMapRunnerEvent(fmt.Sprintf("performing reset after operation chain on map '%s' in goroutine %d in map run %d", mapName, mapNumber, i), l.tle.runnerName, log.InfoLevel)
-			l.resetAfterOperationChain(m, mapName, mapNumber, &keysCache, mc, ac)
+			l.resetAfterOperationChain(m, mapName, mapNumber, &elementsInserted, &elementsAvailableForInsertion, mc, ac)
 		}
 
 	}
@@ -279,20 +245,21 @@ func (l *boundaryTestLoop[t]) runForMap(m hazelcastwrapper.Map, mapName string, 
 
 }
 
-func (l *boundaryTestLoop[t]) resetAfterOperationChain(m hazelcastwrapper.Map, mapName string, mapNumber uint16, keysCache *map[string]struct{}, mc *modeCache, ac *actionCache) {
+func (l *boundaryTestLoop[t]) resetAfterOperationChain(m hazelcastwrapper.Map, mapName string, mapNumber uint16, elementsInserted, elementsAvailableForInsertion *map[string]t, mc *modeCache, ac *actionCache) {
 
 	lp.LogMapRunnerEvent(fmt.Sprintf("resetting mode and action cache for map '%s' on goroutine %d", mapName, mapNumber), l.tle.runnerName, log.TraceLevel)
 
 	*mc = modeCache{}
 	*ac = actionCache{}
 
-	p := assemblePredicate(client.ID(), mapNumber)
+	p := assemblePredicate(client.ID(), mapName, mapNumber)
 	lp.LogMapRunnerEvent(fmt.Sprintf("removing all keys from map '%s' in goroutine %d having match for predicate '%s'", mapName, mapNumber, p), l.tle.runnerName, log.TraceLevel)
 	err := m.RemoveAll(l.tle.ctx, p)
 	if err != nil {
 		lp.LogHzEvent(fmt.Sprintf("won't update local cache because removing all keys from map '%s' in goroutine %d having match for predicate '%s' failed due to error: '%s'", mapName, mapNumber, p, err.Error()), log.WarnLevel)
 	} else {
-		*keysCache = make(map[string]struct{})
+		*elementsInserted = make(map[string]t)
+		*elementsAvailableForInsertion = l.populateElementsAvailableForInsertion(mapName, mapNumber)
 	}
 
 }
@@ -324,7 +291,8 @@ func (l *boundaryTestLoop[t]) runOperationChain(
 	actions *actionCache,
 	mapName string,
 	mapNumber uint16,
-	keysCache map[string]struct{},
+	elementsInserted map[string]t,
+	elementsAvailableForInsertion map[string]t,
 ) error {
 
 	chainLength := l.tle.runnerConfig.boundary.chainLength
@@ -343,14 +311,14 @@ func (l *boundaryTestLoop[t]) runOperationChain(
 			lp.LogMapRunnerEvent(fmt.Sprintf("chain position %d of %d for map '%s' on goroutine %d", j, chainLength, mapName, mapNumber), l.tle.runnerName, log.InfoLevel)
 		}
 
-		nextMode, forceActionTowardsMode := l.checkForModeChange(upperBoundary, lowerBoundary, uint32(len(keysCache)), modes.current)
+		nextMode, forceActionTowardsMode := l.checkForModeChange(upperBoundary, lowerBoundary, uint32(len(elementsInserted)), modes.current)
 		if nextMode != modes.current && modes.current != "" {
-			lp.LogMapRunnerEvent(fmt.Sprintf("detected mode change from '%s' to '%s' for map '%s' in chain position %d with %d map items currently under management", modes.current, nextMode, mapName, j, len(keysCache)), l.tle.runnerName, log.InfoLevel)
+			lp.LogMapRunnerEvent(fmt.Sprintf("detected mode change from '%s' to '%s' for map '%s' in chain position %d with %d map items currently under management", modes.current, nextMode, mapName, j, len(elementsInserted)), l.tle.runnerName, log.InfoLevel)
 			l.s.sleep(l.tle.runnerConfig.boundary.sleepUponModeChange, sleepTimeFunc, l.tle.runnerName)
 		}
 		modes.current, modes.forceActionTowardsMode = nextMode, forceActionTowardsMode
 
-		actions.next = determineNextMapAction(modes, actions.last, actionProbability, len(keysCache))
+		actions.next = determineNextMapAction(modes, actions.last, actionProbability, len(elementsInserted))
 
 		lp.LogMapRunnerEvent(fmt.Sprintf("for map '%s' in goroutine %d, current mode is '%s', and next map action was determined to be '%s'", mapName, mapNumber, modes.current, actions.next), l.tle.runnerName, log.TraceLevel)
 		if actions.next == noop {
@@ -368,7 +336,7 @@ func (l *boundaryTestLoop[t]) runOperationChain(
 			j--
 		}
 
-		nextMapElement, err := l.chooseNextMapElement(actions.next, keysCache, mapNumber)
+		nextMapElement, err := l.chooseNextMapElement(actions.next, elementsInserted, elementsAvailableForInsertion)
 
 		if err != nil {
 			lp.LogMapRunnerEvent(fmt.Sprintf("unable to choose next map element to work on for map '%s' due to error ('%s') -- aborting operation chain to try in next run", mapName, err.Error()), l.tle.runnerName, log.ErrorLevel)
@@ -385,7 +353,8 @@ func (l *boundaryTestLoop[t]) runOperationChain(
 			lp.LogMapRunnerEvent(fmt.Sprintf("encountered error upon execution of '%s' action on map '%s' in run '%d' (still moving to next loop iteration): %v", actions.last, mapName, currentRun, err), l.tle.runnerName, log.WarnLevel)
 		} else {
 			lp.LogMapRunnerEvent(fmt.Sprintf("action '%s' successfully executed on map '%s', moving to next action in upcoming loop iteration", actions.last, mapName), l.tle.runnerName, log.TraceLevel)
-			updateKeysCache(actions.last, keysCache, assembleMapKey(mapNumber, l.tle.getElementID(nextMapElement)), l.tle.runnerName)
+			key := assembleMapKey(mapName, mapNumber, l.tle.getElementID(nextMapElement))
+			l.updateKeysCache(nextMapElement, actions.last, elementsInserted, elementsAvailableForInsertion, key, l.tle.runnerName)
 		}
 
 		l.s.sleep(l.tle.runnerConfig.boundary.sleepAfterChainAction, sleepTimeFunc, l.tle.runnerName)
@@ -396,16 +365,29 @@ func (l *boundaryTestLoop[t]) runOperationChain(
 
 }
 
-func updateKeysCache(lastSuccessfulAction mapAction, keysCache map[string]struct{}, key, runnerName string) {
+func (l *boundaryTestLoop[t]) populateElementsAvailableForInsertion(mapName string, mapNumber uint16) map[string]t {
+
+	notYetInserted := make(map[string]t, len(l.tle.elements))
+	for _, v := range l.tle.elements {
+		notYetInserted[assembleMapKey(mapName, mapNumber, l.tle.getElementID(v))] = v
+	}
+
+	return notYetInserted
+
+}
+
+func (l *boundaryTestLoop[t]) updateKeysCache(element t, lastSuccessfulAction mapAction, elementsInserted, elementsAvailableForInsertion map[string]t, key, runnerName string) {
 
 	switch lastSuccessfulAction {
 	case insert, remove:
 		if lastSuccessfulAction == insert {
-			keysCache[key] = struct{}{}
+			elementsInserted[key] = element
+			delete(elementsAvailableForInsertion, key)
 		} else {
-			delete(keysCache, key)
+			delete(elementsInserted, key)
+			elementsAvailableForInsertion[key] = element
 		}
-		lp.LogMapRunnerEvent(fmt.Sprintf("update on key cache successful for map action '%s', cache now containing %d element/-s", lastSuccessfulAction, len(keysCache)), runnerName, log.TraceLevel)
+		lp.LogMapRunnerEvent(fmt.Sprintf("update on key cache successful for map action '%s', cache now containing %d element/-s", lastSuccessfulAction, len(elementsInserted)), runnerName, log.TraceLevel)
 	default:
 		lp.LogMapRunnerEvent(fmt.Sprintf("no action to perform on local cache for last successful action '%s'", lastSuccessfulAction), runnerName, log.TraceLevel)
 	}
@@ -416,7 +398,7 @@ func (l *boundaryTestLoop[t]) executeMapAction(m hazelcastwrapper.Map, mapName s
 
 	elementID := l.tle.getElementID(element)
 
-	key := assembleMapKey(mapNumber, elementID)
+	key := assembleMapKey(mapName, mapNumber, elementID)
 
 	switch action {
 	case insert:
@@ -672,7 +654,7 @@ func (l *batchTestLoop[t]) ingestAll(m hazelcastwrapper.Map, mapName string, map
 
 	numNewlyIngested := 0
 	for _, v := range l.tle.elements {
-		key := assembleMapKey(mapNumber, l.tle.getElementID(v))
+		key := assembleMapKey(mapName, mapNumber, l.tle.getElementID(v))
 		containsKey, err := m.ContainsKey(l.tle.ctx, key)
 		if err != nil {
 			l.ct.increaseCounter(statusKeyNumFailedKeyChecks)
@@ -702,7 +684,7 @@ func (l *batchTestLoop[t]) ingestAll(m hazelcastwrapper.Map, mapName string, map
 func (l *batchTestLoop[t]) readAll(m hazelcastwrapper.Map, mapName string, mapNumber uint16) error {
 
 	for _, v := range l.tle.elements {
-		key := assembleMapKey(mapNumber, l.tle.getElementID(v))
+		key := assembleMapKey(mapName, mapNumber, l.tle.getElementID(v))
 		valueFromHZ, err := m.Get(l.tle.ctx, key)
 		if err != nil {
 			l.ct.increaseCounter(statusKeyNumFailedReads)
@@ -729,7 +711,7 @@ func (l *batchTestLoop[t]) removeSome(m hazelcastwrapper.Map, mapName string, ma
 	elements := l.tle.elements
 
 	for i := 0; i < numElementsToDelete; i++ {
-		key := assembleMapKey(mapNumber, l.tle.getElementID(elements[i]))
+		key := assembleMapKey(mapName, mapNumber, l.tle.getElementID(elements[i]))
 		containsKey, err := m.ContainsKey(l.tle.ctx, key)
 		if err != nil {
 			return err
@@ -779,8 +761,8 @@ func (s *defaultSleeper) sleep(sc *sleepConfig, sf evaluateTimeToSleep, runnerNa
 
 }
 
-func assembleMapKey(mapNumber uint16, elementID string) string {
+func assembleMapKey(mapName string, mapNumber uint16, elementID string) string {
 
-	return fmt.Sprintf("%s-%d-%s", client.ID(), mapNumber, elementID)
+	return fmt.Sprintf("%s-%s-%d-%s", client.ID(), mapName, mapNumber, elementID)
 
 }

--- a/maps/testloop.go
+++ b/maps/testloop.go
@@ -418,7 +418,6 @@ func (l *boundaryTestLoop[t]) executeMapAction(m hazelcastwrapper.Map, mapName s
 
 	switch action {
 	case insert:
-		// TODO Write test case for this
 		payload, err := l.tle.getOrAssemblePayload(mapName, mapNumber, element)
 		if err != nil {
 			lp.LogMapRunnerEvent(fmt.Sprintf("unable to execute insert operation for map '%s' due to error upon generating payload: %v", mapName, err), l.tle.runnerName, log.ErrorLevel)

--- a/maps/testloop.go
+++ b/maps/testloop.go
@@ -679,13 +679,11 @@ func (l *batchTestLoop[t]) ingestAll(m hazelcastwrapper.Map, mapName string, map
 		if containsKey {
 			continue
 		}
-		// TODO Write test case around this
 		value, err := l.tle.getOrAssemblePayload(mapName, mapNumber, v)
 		if err != nil {
 			return err
 		}
 		if err = m.Set(l.tle.ctx, key, value); err != nil {
-			// TODO Write test case to verify inserted value had random payload
 			l.ct.increaseCounter(statusKeyNumFailedInserts)
 			return err
 		}

--- a/maps/testloop.go
+++ b/maps/testloop.go
@@ -377,12 +377,14 @@ func (l *boundaryTestLoop[t]) runOperationChain(
 
 		lp.LogMapRunnerEvent(fmt.Sprintf("successfully chose next map element for map '%s' in goroutine %d for map action '%s'", mapName, mapNumber, actions.next), l.tle.runnerName, log.TraceLevel)
 
-		if err := l.executeMapAction(m, mapName, mapNumber, nextMapElement, actions.next); err != nil {
-			lp.LogMapRunnerEvent(fmt.Sprintf("encountered error upon execution of '%s' action on map '%s' in iteration '%d': %v", actions.next, mapName, currentRun, err), l.tle.runnerName, log.WarnLevel)
+		err = l.executeMapAction(m, mapName, mapNumber, nextMapElement, actions.next)
+		actions.last = actions.next
+		actions.next = ""
+
+		if err != nil {
+			lp.LogMapRunnerEvent(fmt.Sprintf("encountered error upon execution of '%s' action on map '%s' in run '%d' (still moving to next loop iteration): %v", actions.last, mapName, currentRun, err), l.tle.runnerName, log.WarnLevel)
 		} else {
-			lp.LogMapRunnerEvent(fmt.Sprintf("action '%s' successfully executed on map '%s', moving to next action in upcoming loop", actions.next, mapName), l.tle.runnerName, log.TraceLevel)
-			actions.last = actions.next
-			actions.next = ""
+			lp.LogMapRunnerEvent(fmt.Sprintf("action '%s' successfully executed on map '%s', moving to next action in upcoming loop iteration", actions.last, mapName), l.tle.runnerName, log.TraceLevel)
 			updateKeysCache(actions.last, keysCache, assembleMapKey(mapNumber, l.tle.getElementID(nextMapElement)), l.tle.runnerName)
 		}
 

--- a/maps/testloop.go
+++ b/maps/testloop.go
@@ -72,7 +72,7 @@ type (
 		getOrAssemblePayload getOrAssemblePayloadFunc
 	}
 	mapTestLoopCountersTracker struct {
-		counters map[statusKey]int
+		counters map[statusKey]uint64
 		l        sync.Mutex
 		gatherer *status.Gatherer
 	}
@@ -127,9 +127,9 @@ var (
 func (ct *mapTestLoopCountersTracker) init(gatherer *status.Gatherer) {
 	ct.gatherer = gatherer
 
-	ct.counters = make(map[statusKey]int)
+	ct.counters = make(map[statusKey]uint64)
 
-	initialCounterValue := 0
+	initialCounterValue := uint64(0)
 	for _, v := range counters {
 		ct.counters[v] = initialCounterValue
 		gatherer.Updates <- status.Update{Key: string(v), Value: initialCounterValue}
@@ -138,7 +138,7 @@ func (ct *mapTestLoopCountersTracker) init(gatherer *status.Gatherer) {
 
 func (ct *mapTestLoopCountersTracker) increaseCounter(sk statusKey) {
 
-	var newValue int
+	var newValue uint64
 	ct.l.Lock()
 	{
 		newValue = ct.counters[sk] + 1

--- a/maps/testloop_test.go
+++ b/maps/testloop_test.go
@@ -2949,7 +2949,7 @@ func TestReadAll(t *testing.T) {
 			populateTestHzMapStore(&ms)
 
 			go tl.gatherer.Listen()
-			err := tl.readAll(ms.m, mapBaseName, 0)
+			err := tl.readAll(ms.m, testMapBaseName, 0)
 			tl.gatherer.StopListen()
 
 			waitForStatusGatheringDone(tl.gatherer)
@@ -2997,7 +2997,7 @@ func TestReadAll(t *testing.T) {
 			tl := assembleBatchTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
 
 			go tl.gatherer.Listen()
-			err := tl.readAll(ms.m, mapBaseName, 0)
+			err := tl.readAll(ms.m, testMapBaseName, 0)
 			tl.gatherer.StopListen()
 
 			msg := "\t\terror must be returned"
@@ -3036,7 +3036,7 @@ func TestReadAll(t *testing.T) {
 			ms.m.data.Store(assembleMapKey(0, "legolas"), nil)
 
 			go tl.gatherer.Listen()
-			err := tl.readAll(ms.m, mapBaseName, 0)
+			err := tl.readAll(ms.m, testMapBaseName, 0)
 			tl.gatherer.StopListen()
 
 			msg := "\t\terror must be returned"
@@ -3131,7 +3131,7 @@ func TestRemoveSome(t *testing.T) {
 			statusRecord := map[statusKey]any{
 				statusKeyNumFailedRemoves: 0,
 			}
-			err := tl.removeSome(ms.m, mapBaseName, uint16(0))
+			err := tl.removeSome(ms.m, testMapBaseName, uint16(0))
 
 			msg := "\t\tno error must be returned"
 			if err == nil {
@@ -3169,7 +3169,7 @@ func TestRemoveSome(t *testing.T) {
 			populateTestHzMapStore(&ms)
 
 			go tl.gatherer.Listen()
-			err := tl.removeSome(ms.m, mapBaseName, uint16(0))
+			err := tl.removeSome(ms.m, testMapBaseName, uint16(0))
 			tl.gatherer.StopListen()
 
 			msg := "\t\terror must be returned"

--- a/maps/testloop_test.go
+++ b/maps/testloop_test.go
@@ -3341,16 +3341,21 @@ func assembleBatchTestLoop(id uuid.UUID, source string, ch hazelcastwrapper.HzCl
 func assembleTestLoopExecution(id uuid.UUID, source string, rc *runnerConfig, ch hazelcastwrapper.HzClientHandler, ms hazelcastwrapper.MapStore) testLoopExecution[string] {
 
 	return testLoopExecution[string]{
-		id:              id,
-		source:          source,
-		hzClientHandler: ch,
-		hzMapStore:      ms,
-		runnerConfig:    rc,
-		elements:        theFellowship,
-		ctx:             nil,
-		getElementID:    fellowshipMemberName,
+		id:                   id,
+		source:               source,
+		hzClientHandler:      ch,
+		hzMapStore:           ms,
+		runnerConfig:         rc,
+		elements:             theFellowship,
+		ctx:                  nil,
+		getElementID:         fellowshipMemberName,
+		getOrAssemblePayload: returnFellowshipMemberName,
 	}
 
+}
+
+func returnFellowshipMemberName(_ string, _ uint16, element any) (any, error) {
+	return element, nil
 }
 
 func assembleTestMapStoreWithBoundaryMonitoring(b *testMapStoreBehavior, bm *boundaryMonitoring) testHzMapStore {

--- a/maps/testloop_test.go
+++ b/maps/testloop_test.go
@@ -238,7 +238,7 @@ func TestChooseNextMapElement(t *testing.T) {
 				tl := boundaryTestLoop[string]{
 					tle: &testLoopExecution[string]{
 						elements: theFellowship,
-						getElementIdFunc: func(element any) string {
+						getElementID: func(element any) string {
 							return element.(string)
 						},
 					},
@@ -275,7 +275,7 @@ func TestChooseNextMapElement(t *testing.T) {
 						elements: []string{
 							theFellowship[0],
 						},
-						getElementIdFunc: func(element any) string {
+						getElementID: func(element any) string {
 							return element.(string)
 						},
 					},
@@ -347,7 +347,7 @@ func TestChooseNextMapElement(t *testing.T) {
 							elements: []string{
 								elementInSourceData,
 							},
-							getElementIdFunc: func(element any) string {
+							getElementID: func(element any) string {
 								return element.(string)
 							},
 						},
@@ -381,7 +381,7 @@ func TestChooseNextMapElement(t *testing.T) {
 					tl := boundaryTestLoop[string]{
 						tle: &testLoopExecution[string]{
 							elements: theFellowship,
-							getElementIdFunc: func(element any) string {
+							getElementID: func(element any) string {
 								return "So you have chosen... death."
 							},
 						},
@@ -3341,14 +3341,14 @@ func assembleBatchTestLoop(id uuid.UUID, source string, ch hazelcastwrapper.HzCl
 func assembleTestLoopExecution(id uuid.UUID, source string, rc *runnerConfig, ch hazelcastwrapper.HzClientHandler, ms hazelcastwrapper.MapStore) testLoopExecution[string] {
 
 	return testLoopExecution[string]{
-		id:               id,
-		source:           source,
-		hzClientHandler:  ch,
-		hzMapStore:       ms,
-		runnerConfig:     rc,
-		elements:         theFellowship,
-		ctx:              nil,
-		getElementIdFunc: fellowshipMemberName,
+		id:              id,
+		source:          source,
+		hzClientHandler: ch,
+		hzMapStore:      ms,
+		runnerConfig:    rc,
+		elements:        theFellowship,
+		ctx:             nil,
+		getElementID:    fellowshipMemberName,
 	}
 
 }

--- a/maps/testloop_test.go
+++ b/maps/testloop_test.go
@@ -812,273 +812,287 @@ func TestExecuteMapAction(t *testing.T) {
 		{
 			t.Log("\t\twhen target map does not contain key yet")
 			{
-				getOrAssembleObservations = getOrAssemblePayloadFunctionObservations{}
-				getOrAssembleBehavior = getOrAssemblePayloadFunctionBehavior{}
+				func() {
+					defer resetGetOrAssemblePayloadTestSetup()
 
-				ms := assembleTestMapStore(&testMapStoreBehavior{})
-				rc := assembleRunnerConfigForBoundaryTestLoop(
-					rpOneMapOneRunNoEvictionScDisabled,
-					sleepConfigDisabled,
-					sleepConfigDisabled,
-					1.0,
-					0.0,
-					0.5,
-					42,
-					true,
-				)
-				tl := assembleBoundaryTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
-				action := insert
+					ms := assembleTestMapStore(&testMapStoreBehavior{})
+					rc := assembleRunnerConfigForBoundaryTestLoop(
+						rpOneMapOneRunNoEvictionScDisabled,
+						sleepConfigDisabled,
+						sleepConfigDisabled,
+						1.0,
+						0.0,
+						0.5,
+						42,
+						true,
+					)
+					tl := assembleBoundaryTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+					action := insert
 
-				mapNumber := 0
-				mapName := fmt.Sprintf("%s-%s-%d", rc.mapPrefix, rc.mapBaseName, mapNumber)
-				go tl.gatherer.Listen()
-				err := tl.executeMapAction(ms.m, mapName, uint16(mapNumber), theFellowship[0], action)
-				tl.gatherer.StopListen()
+					mapNumber := 0
+					mapName := fmt.Sprintf("%s-%s-%d", rc.mapPrefix, rc.mapBaseName, mapNumber)
+					go tl.gatherer.Listen()
+					err := tl.executeMapAction(ms.m, mapName, uint16(mapNumber), theFellowship[0], action)
+					tl.gatherer.StopListen()
 
-				msg := "\t\t\tno error must be returned"
+					msg := "\t\t\tno error must be returned"
 
-				if err == nil {
-					t.Log(msg, checkMark)
-				} else {
-					t.Fatal(msg, ballotX, err)
-				}
+					if err == nil {
+						t.Log(msg, checkMark)
+					} else {
+						t.Fatal(msg, ballotX, err)
+					}
 
-				msg = "\t\t\tno contains key check must have been executed"
-				if ms.m.containsKeyInvocations == 0 {
-					t.Log(msg, checkMark)
-				} else {
-					t.Fatal(msg, ballotX, fmt.Sprintf("expected 0 invocations, got %d", ms.m.containsKeyInvocations))
-				}
+					msg = "\t\t\tno contains key check must have been executed"
+					if ms.m.containsKeyInvocations == 0 {
+						t.Log(msg, checkMark)
+					} else {
+						t.Fatal(msg, ballotX, fmt.Sprintf("expected 0 invocations, got %d", ms.m.containsKeyInvocations))
+					}
 
-				msg = "\t\t\tset operation must have been executed once"
-				if ms.m.setInvocations == 1 {
-					t.Log(msg, checkMark)
-				} else {
-					t.Fatal(msg, ballotX, fmt.Sprintf("expected 1 invocation, got %d", ms.m.setInvocations))
-				}
+					msg = "\t\t\tset operation must have been executed once"
+					if ms.m.setInvocations == 1 {
+						t.Log(msg, checkMark)
+					} else {
+						t.Fatal(msg, ballotX, fmt.Sprintf("expected 1 invocation, got %d", ms.m.setInvocations))
+					}
 
-				msg = "\t\t\tmap must contain one element"
-				count := 0
-				ms.m.data.Range(func(_, _ any) bool {
-					count++
-					return true
-				})
-				if count == 1 {
-					t.Log(msg, checkMark)
-				} else {
-					t.Fatal(msg, ballotX, fmt.Sprintf("expected 1 element, got %d", count))
-				}
+					msg = "\t\t\tmap must contain one element"
+					count := 0
+					ms.m.data.Range(func(_, _ any) bool {
+						count++
+						return true
+					})
+					if count == 1 {
+						t.Log(msg, checkMark)
+					} else {
+						t.Fatal(msg, ballotX, fmt.Sprintf("expected 1 element, got %d", count))
+					}
 
-				waitForStatusGatheringDone(tl.gatherer)
+					waitForStatusGatheringDone(tl.gatherer)
 
-				msg = "\t\t\tstatus gatherer must indicate zero failed insert operations"
-				if ok, detail := expectedStatusPresent(tl.gatherer.AssembleStatusCopy(), statusKeyNumFailedInserts, 0); ok {
-					t.Log(msg, checkMark)
-				} else {
-					t.Fatal(msg, ballotX, detail)
-				}
+					msg = "\t\t\tstatus gatherer must indicate zero failed insert operations"
+					if ok, detail := expectedStatusPresent(tl.gatherer.AssembleStatusCopy(), statusKeyNumFailedInserts, 0); ok {
+						t.Log(msg, checkMark)
+					} else {
+						t.Fatal(msg, ballotX, detail)
+					}
 
-				msg = "\t\t\tget or assemble payload function must have been invoked once"
-				if getOrAssembleObservations.numInvocations == 1 {
-					t.Log(msg, checkMark)
-				} else {
-					t.Fatal(msg, ballotX)
-				}
+					msg = "\t\t\tget or assemble payload function must have been invoked once"
+					if getOrAssembleObservations.numInvocations == 1 {
+						t.Log(msg, checkMark)
+					} else {
+						t.Fatal(msg, ballotX)
+					}
+				}()
 			}
 			t.Log("\t\twhen target map does not contain key yet and set yields error")
 			{
-				getOrAssembleObservations = getOrAssemblePayloadFunctionObservations{}
-				getOrAssembleBehavior = getOrAssemblePayloadFunctionBehavior{}
+				func() {
+					defer resetGetOrAssemblePayloadTestSetup()
 
-				ms := assembleTestMapStore(&testMapStoreBehavior{returnErrorUponSet: true})
-				rc := assembleRunnerConfigForBoundaryTestLoop(
-					rpOneMapOneRunNoEvictionScDisabled,
-					sleepConfigDisabled,
-					sleepConfigDisabled,
-					1.0,
-					0.0,
-					0.5,
-					42,
-					true,
-				)
-				tl := assembleBoundaryTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+					ms := assembleTestMapStore(&testMapStoreBehavior{returnErrorUponSet: true})
+					rc := assembleRunnerConfigForBoundaryTestLoop(
+						rpOneMapOneRunNoEvictionScDisabled,
+						sleepConfigDisabled,
+						sleepConfigDisabled,
+						1.0,
+						0.0,
+						0.5,
+						42,
+						true,
+					)
+					tl := assembleBoundaryTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
 
-				go tl.gatherer.Listen()
-				err := tl.executeMapAction(ms.m, "awesome-map-name", 0, theFellowship[0], insert)
-				tl.gatherer.StopListen()
+					go tl.gatherer.Listen()
+					err := tl.executeMapAction(ms.m, "awesome-map-name", 0, theFellowship[0], insert)
+					tl.gatherer.StopListen()
 
-				msg := "\t\t\terror must be returned"
-				if err != nil {
-					t.Log(msg, checkMark)
-				} else {
-					t.Fatal(msg, ballotX)
-				}
+					msg := "\t\t\terror must be returned"
+					if err != nil {
+						t.Log(msg, checkMark)
+					} else {
+						t.Fatal(msg, ballotX)
+					}
 
-				waitForStatusGatheringDone(tl.gatherer)
+					waitForStatusGatheringDone(tl.gatherer)
 
-				msg = "\t\t\ttest loop must have informed status gatherer about error"
-				statusCopy := tl.gatherer.AssembleStatusCopy()
-				if ok, detail := expectedStatusPresent(statusCopy, statusKeyNumFailedInserts, 1); ok {
-					t.Log(msg, checkMark)
-				} else {
-					t.Fatal(msg, ballotX, detail)
-				}
+					msg = "\t\t\ttest loop must have informed status gatherer about error"
+					statusCopy := tl.gatherer.AssembleStatusCopy()
+					if ok, detail := expectedStatusPresent(statusCopy, statusKeyNumFailedInserts, 1); ok {
+						t.Log(msg, checkMark)
+					} else {
+						t.Fatal(msg, ballotX, detail)
+					}
 
-				msg = "\t\t\tget or assemble payload function must have been invoked nonetheless"
-				if getOrAssembleObservations.numInvocations == 1 {
-					t.Log(msg, checkMark)
-				} else {
-					t.Fatal(msg, ballotX)
-				}
+					msg = "\t\t\tget or assemble payload function must have been invoked nonetheless"
+					if getOrAssembleObservations.numInvocations == 1 {
+						t.Log(msg, checkMark)
+					} else {
+						t.Fatal(msg, ballotX)
+					}
+				}()
 
 			}
 			t.Log("\t\twhen target map already contains key")
 			{
-				getOrAssembleObservations = getOrAssemblePayloadFunctionObservations{}
-				getOrAssembleBehavior = getOrAssemblePayloadFunctionBehavior{}
+				func() {
+					defer resetGetOrAssemblePayloadTestSetup()
 
-				ms := assembleTestMapStore(&testMapStoreBehavior{})
-				rc := assembleRunnerConfigForBoundaryTestLoop(
-					rpOneMapOneRunNoEvictionScDisabled,
-					sleepConfigDisabled,
-					sleepConfigDisabled,
-					1.0,
-					0.0,
-					0.5,
-					42,
-					true,
-				)
-				tl := assembleBoundaryTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
-				action := insert
+					ms := assembleTestMapStore(&testMapStoreBehavior{})
+					rc := assembleRunnerConfigForBoundaryTestLoop(
+						rpOneMapOneRunNoEvictionScDisabled,
+						sleepConfigDisabled,
+						sleepConfigDisabled,
+						1.0,
+						0.0,
+						0.5,
+						42,
+						true,
+					)
+					tl := assembleBoundaryTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+					action := insert
 
-				mapNumber := uint16(0)
-				populateTestHzMapStore(&ms)
-				mapName := fmt.Sprintf("%s-%s-%d", rc.mapPrefix, rc.mapBaseName, mapNumber)
+					mapNumber := uint16(0)
+					populateTestHzMapStore(&ms)
+					mapName := fmt.Sprintf("%s-%s-%d", rc.mapPrefix, rc.mapBaseName, mapNumber)
 
-				err := tl.executeMapAction(ms.m, mapName, mapNumber, theFellowship[0], action)
+					err := tl.executeMapAction(ms.m, mapName, mapNumber, theFellowship[0], action)
 
-				msg := "\t\t\tno error must be returned"
-				if err == nil {
-					t.Log(msg, checkMark)
-				} else {
-					t.Fatal(msg, ballotX)
-				}
+					msg := "\t\t\tno error must be returned"
+					if err == nil {
+						t.Log(msg, checkMark)
+					} else {
+						t.Fatal(msg, ballotX)
+					}
 
-				msg = "\t\t\tset invocation must have been attempted anyway"
-				if ms.m.setInvocations == 1 {
-					t.Log(msg, checkMark)
-				} else {
-					t.Fatal(msg, ballotX, fmt.Sprintf("expected no invocations, got %d", ms.m.setInvocations))
-				}
+					msg = "\t\t\tset invocation must have been attempted anyway"
+					if ms.m.setInvocations == 1 {
+						t.Log(msg, checkMark)
+					} else {
+						t.Fatal(msg, ballotX, fmt.Sprintf("expected no invocations, got %d", ms.m.setInvocations))
+					}
 
-				msg = "\t\t\tget or assemble payload function must have been invoked anyway"
-				if getOrAssembleObservations.numInvocations == 1 {
-					t.Log(msg, checkMark)
-				} else {
-					t.Fatal(msg, ballotX)
-				}
+					msg = "\t\t\tget or assemble payload function must have been invoked anyway"
+					if getOrAssembleObservations.numInvocations == 1 {
+						t.Log(msg, checkMark)
+					} else {
+						t.Fatal(msg, ballotX)
+					}
+				}()
 
 			}
 			t.Log("\t\twhen get or assemble payload function yields error")
 			{
-				getOrAssembleObservations = getOrAssemblePayloadFunctionObservations{}
-				getOrAssembleBehavior = getOrAssemblePayloadFunctionBehavior{returnError: true}
+				func() {
+					defer resetGetOrAssemblePayloadTestSetup()
 
-				ms := assembleTestMapStore(&testMapStoreBehavior{})
-				rc := assembleRunnerConfigForBoundaryTestLoop(
-					rpOneMapOneRunNoEvictionScDisabled,
-					sleepConfigDisabled,
-					sleepConfigDisabled,
-					1.0,
-					0.0,
-					0.5,
-					42,
-					true,
-				)
-				tl := assembleBoundaryTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
-				action := insert
+					getOrAssembleBehavior = getOrAssemblePayloadFunctionBehavior{returnError: true}
 
-				mapNumber := 0
-				mapName := fmt.Sprintf("%s-%s-%d", rc.mapPrefix, rc.mapBaseName, mapNumber)
-				go tl.gatherer.Listen()
-				err := tl.executeMapAction(ms.m, mapName, uint16(mapNumber), theFellowship[0], action)
-				tl.gatherer.StopListen()
+					ms := assembleTestMapStore(&testMapStoreBehavior{})
+					rc := assembleRunnerConfigForBoundaryTestLoop(
+						rpOneMapOneRunNoEvictionScDisabled,
+						sleepConfigDisabled,
+						sleepConfigDisabled,
+						1.0,
+						0.0,
+						0.5,
+						42,
+						true,
+					)
+					tl := assembleBoundaryTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+					action := insert
 
-				msg := "\t\t\terror must be returned"
-				if errors.Is(err, getOrAssemblePayloadError) {
-					t.Log(msg, checkMark)
-				} else {
-					t.Fatal(msg, ballotX)
-				}
+					mapNumber := 0
+					mapName := fmt.Sprintf("%s-%s-%d", rc.mapPrefix, rc.mapBaseName, mapNumber)
+					go tl.gatherer.Listen()
+					err := tl.executeMapAction(ms.m, mapName, uint16(mapNumber), theFellowship[0], action)
+					tl.gatherer.StopListen()
 
-				msg = "\t\t\tno set on map must have been attempted"
-				if ms.m.setInvocations == 0 {
-					t.Log(msg, checkMark)
-				} else {
-					t.Fatal(msg, ballotX, ms.m.setInvocations)
-				}
+					msg := "\t\t\terror must be returned"
+					if errors.Is(err, getOrAssemblePayloadError) {
+						t.Log(msg, checkMark)
+					} else {
+						t.Fatal(msg, ballotX)
+					}
+
+					msg = "\t\t\tno set on map must have been attempted"
+					if ms.m.setInvocations == 0 {
+						t.Log(msg, checkMark)
+					} else {
+						t.Fatal(msg, ballotX, ms.m.setInvocations)
+					}
+
+					msg = "\t\t\tget or assemble payload function must have been invoked only once"
+					if getOrAssembleObservations.numInvocations == 1 {
+						t.Log(msg, checkMark)
+					} else {
+						t.Fatal(msg, ballotX, getOrAssembleObservations.numInvocations)
+					}
+				}()
 			}
 		}
 		t.Log("\twhen next action is remove")
 		{
 			t.Log("\t\twhen target map does not contain key")
 			{
-				getOrAssembleObservations = getOrAssemblePayloadFunctionObservations{}
-				getOrAssembleBehavior = getOrAssemblePayloadFunctionBehavior{}
+				func() {
+					defer resetGetOrAssemblePayloadTestSetup()
 
-				rc := assembleRunnerConfigForBoundaryTestLoop(
-					rpOneMapOneRunNoEvictionScDisabled,
-					sleepConfigDisabled,
-					sleepConfigDisabled,
-					1.0,
-					0.0,
-					0.5,
-					42,
-					true,
-				)
-				ms := assembleTestMapStore(&testMapStoreBehavior{})
-				tl := assembleBoundaryTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+					rc := assembleRunnerConfigForBoundaryTestLoop(
+						rpOneMapOneRunNoEvictionScDisabled,
+						sleepConfigDisabled,
+						sleepConfigDisabled,
+						1.0,
+						0.0,
+						0.5,
+						42,
+						true,
+					)
+					ms := assembleTestMapStore(&testMapStoreBehavior{})
+					tl := assembleBoundaryTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
 
-				go tl.gatherer.Listen()
-				err := tl.executeMapAction(ms.m, "my-map-name", uint16(0), theFellowship[0], remove)
-				tl.gatherer.StopListen()
+					go tl.gatherer.Listen()
+					err := tl.executeMapAction(ms.m, "my-map-name", uint16(0), theFellowship[0], remove)
+					tl.gatherer.StopListen()
 
-				msg := "\t\t\tno error must be returned"
-				if err == nil {
-					t.Log(msg, checkMark)
-				} else {
-					t.Fatal(msg, ballotX, err)
-				}
+					msg := "\t\t\tno error must be returned"
+					if err == nil {
+						t.Log(msg, checkMark)
+					} else {
+						t.Fatal(msg, ballotX, err)
+					}
 
-				msg = "\t\t\tno check for key must have been performed"
-				if ms.m.containsKeyInvocations == 0 {
-					t.Log(msg, checkMark)
-				} else {
-					t.Fatal(msg, ballotX, fmt.Sprintf("expected 1 invocation, got %d", ms.m.containsKeyInvocations))
-				}
+					msg = "\t\t\tno check for key must have been performed"
+					if ms.m.containsKeyInvocations == 0 {
+						t.Log(msg, checkMark)
+					} else {
+						t.Fatal(msg, ballotX, fmt.Sprintf("expected 1 invocation, got %d", ms.m.containsKeyInvocations))
+					}
 
-				msg = "\t\t\tremove must have been attempted anyway"
-				if ms.m.removeInvocations == 1 {
-					t.Log(msg, checkMark)
-				} else {
-					t.Fatal(msg, ballotX, fmt.Sprintf("expected 0 remove invocations, got %d", ms.m.removeInvocations))
-				}
+					msg = "\t\t\tremove must have been attempted anyway"
+					if ms.m.removeInvocations == 1 {
+						t.Log(msg, checkMark)
+					} else {
+						t.Fatal(msg, ballotX, fmt.Sprintf("expected 0 remove invocations, got %d", ms.m.removeInvocations))
+					}
 
-				waitForStatusGatheringDone(tl.gatherer)
+					waitForStatusGatheringDone(tl.gatherer)
 
-				msg = "\t\t\tstatus gatherer must indicate zero failed remove attempts"
-				if ok, detail := expectedStatusPresent(tl.gatherer.AssembleStatusCopy(), statusKeyNumFailedRemoves, 0); ok {
-					t.Log(msg, checkMark)
-				} else {
-					t.Fatal(msg, ballotX, detail)
-				}
+					msg = "\t\t\tstatus gatherer must indicate zero failed remove attempts"
+					if ok, detail := expectedStatusPresent(tl.gatherer.AssembleStatusCopy(), statusKeyNumFailedRemoves, 0); ok {
+						t.Log(msg, checkMark)
+					} else {
+						t.Fatal(msg, ballotX, detail)
+					}
 
-				msg = "\t\t\tget or assemble payload function must not have been invoked"
-				if getOrAssembleObservations.numInvocations == 0 {
-					t.Log(msg, checkMark)
-				} else {
-					t.Fatal(msg, ballotX)
-				}
+					msg = "\t\t\tget or assemble payload function must not have been invoked"
+					if getOrAssembleObservations.numInvocations == 0 {
+						t.Log(msg, checkMark)
+					} else {
+						t.Fatal(msg, ballotX)
+					}
+				}()
 			}
 
 			t.Log("\t\twhen target map contains key and remove yields error")
@@ -1287,53 +1301,53 @@ func TestExecuteMapAction(t *testing.T) {
 
 			t.Log("\t\twhen target map contains key and get does not yield error")
 			{
-				getOrAssembleObservations = getOrAssemblePayloadFunctionObservations{}
-				getOrAssembleBehavior = getOrAssemblePayloadFunctionBehavior{}
+				func() {
 
-				rc := assembleRunnerConfigForBoundaryTestLoop(
-					rpOneMapOneRunNoEvictionScDisabled,
-					sleepConfigDisabled,
-					sleepConfigDisabled,
-					1.0,
-					0.0,
-					0.5,
-					42,
-					true,
-				)
-				ms := assembleTestMapStore(&testMapStoreBehavior{})
-				tl := assembleBoundaryTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+					rc := assembleRunnerConfigForBoundaryTestLoop(
+						rpOneMapOneRunNoEvictionScDisabled,
+						sleepConfigDisabled,
+						sleepConfigDisabled,
+						1.0,
+						0.0,
+						0.5,
+						42,
+						true,
+					)
+					ms := assembleTestMapStore(&testMapStoreBehavior{})
+					tl := assembleBoundaryTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
 
-				populateTestHzMapStore(&ms)
+					populateTestHzMapStore(&ms)
 
-				err := tl.executeMapAction(ms.m, "my-map-name", uint16(0), theFellowship[0], read)
+					err := tl.executeMapAction(ms.m, "my-map-name", uint16(0), theFellowship[0], read)
 
-				msg := "\t\t\tno error must be returned"
-				if err == nil {
-					t.Log(msg, checkMark)
-				} else {
-					t.Fatal(msg, ballotX)
-				}
+					msg := "\t\t\tno error must be returned"
+					if err == nil {
+						t.Log(msg, checkMark)
+					} else {
+						t.Fatal(msg, ballotX)
+					}
 
-				msg = "\t\t\tno check for key must have been performed"
-				if ms.m.containsKeyInvocations == 0 {
-					t.Log(msg, checkMark)
-				} else {
-					t.Fatal(msg, ballotX, fmt.Sprintf("expected 1 invocation, got %d", ms.m.containsKeyInvocations))
-				}
+					msg = "\t\t\tno check for key must have been performed"
+					if ms.m.containsKeyInvocations == 0 {
+						t.Log(msg, checkMark)
+					} else {
+						t.Fatal(msg, ballotX, fmt.Sprintf("expected 1 invocation, got %d", ms.m.containsKeyInvocations))
+					}
 
-				msg = "\t\t\tone read must have been attempted"
-				if ms.m.getInvocations == 1 {
-					t.Log(msg, checkMark)
-				} else {
-					t.Fatal(msg, ballotX, fmt.Sprintf("expected 1 invocation, got %d", ms.m.getInvocations))
-				}
+					msg = "\t\t\tone read must have been attempted"
+					if ms.m.getInvocations == 1 {
+						t.Log(msg, checkMark)
+					} else {
+						t.Fatal(msg, ballotX, fmt.Sprintf("expected 1 invocation, got %d", ms.m.getInvocations))
+					}
 
-				msg = "\t\t\tget or assemble payload function must not have been invoked"
-				if getOrAssembleObservations.numInvocations == 0 {
-					t.Log(msg, checkMark)
-				} else {
-					t.Fatal(msg, ballotX)
-				}
+					msg = "\t\t\tget or assemble payload function must not have been invoked"
+					if getOrAssembleObservations.numInvocations == 0 {
+						t.Log(msg, checkMark)
+					} else {
+						t.Fatal(msg, ballotX)
+					}
+				}()
 
 			}
 		}
@@ -2457,202 +2471,218 @@ func TestRunWithBatchTestLoop(t *testing.T) {
 	{
 		t.Log("\twhen only one map goroutine is used and the test loop runs only once")
 		{
-			id := uuid.New()
-			ms := assembleTestMapStore(&testMapStoreBehavior{})
-			numMaps, numRuns := uint16(1), uint32(1)
-			rc := assembleRunnerConfigForBatchTestLoop(
-				&runnerProperties{
-					numMaps:             numMaps,
-					numRuns:             numRuns,
-					cleanMapsPriorToRun: false,
-					sleepBetweenRuns:    sleepConfigDisabled,
-				},
-				sleepConfigDisabled,
-				sleepConfigDisabled,
-			)
-			tl := assembleBatchTestLoop(id, testSource, &testHzClientHandler{}, ms, rc)
+			func() {
+				defer resetGetOrAssemblePayloadTestSetup()
 
-			go tl.gatherer.Listen()
-			tl.run()
-			tl.gatherer.StopListen()
+				id := uuid.New()
+				ms := assembleTestMapStore(&testMapStoreBehavior{})
+				numMaps, numRuns := uint16(1), uint32(1)
+				rc := assembleRunnerConfigForBatchTestLoop(
+					&runnerProperties{
+						numMaps:             numMaps,
+						numRuns:             numRuns,
+						cleanMapsPriorToRun: false,
+						sleepBetweenRuns:    sleepConfigDisabled,
+					},
+					sleepConfigDisabled,
+					sleepConfigDisabled,
+				)
+				tl := assembleBatchTestLoop(id, testSource, &testHzClientHandler{}, ms, rc)
 
-			waitForStatusGatheringDone(tl.gatherer)
+				go tl.gatherer.Listen()
+				tl.run()
+				tl.gatherer.StopListen()
 
-			expectedNumSetInvocations := len(theFellowship)
-			expectedNumGetInvocations := len(theFellowship)
-			expectedNumDestroyInvocations := 1
+				waitForStatusGatheringDone(tl.gatherer)
 
-			msg := "\t\texpected predictable invocations on map must have been executed"
+				expectedNumSetInvocations := len(theFellowship)
+				expectedNumGetInvocations := len(theFellowship)
+				expectedNumDestroyInvocations := 1
 
-			if expectedNumSetInvocations == ms.m.setInvocations &&
-				expectedNumGetInvocations == ms.m.getInvocations &&
-				expectedNumDestroyInvocations == ms.m.destroyInvocations {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX)
-			}
+				msg := "\t\texpected predictable invocations on map must have been executed"
 
-			msg = "\t\texpected invocations based on random element in test loop must have been executed"
+				if expectedNumSetInvocations == ms.m.setInvocations &&
+					expectedNumGetInvocations == ms.m.getInvocations &&
+					expectedNumDestroyInvocations == ms.m.destroyInvocations {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX)
+				}
 
-			expectedContainsKeyInvocations := expectedNumSetInvocations + ms.m.removeInvocations
-			if expectedContainsKeyInvocations == ms.m.containsKeyInvocations {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX)
-			}
+				msg = "\t\texpected invocations based on random element in test loop must have been executed"
 
-			msg = "\t\tvalues in test loop status must be correct"
+				expectedContainsKeyInvocations := expectedNumSetInvocations + ms.m.removeInvocations
+				if expectedContainsKeyInvocations == ms.m.containsKeyInvocations {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX)
+				}
 
-			if ok, key, detail := statusContainsExpectedValues(tl.gatherer.AssembleStatusCopy(), numMaps, numRuns, uint32(numMaps)*numRuns, true); ok {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX, key, detail)
-			}
+				msg = "\t\tvalues in test loop status must be correct"
+
+				if ok, key, detail := statusContainsExpectedValues(tl.gatherer.AssembleStatusCopy(), numMaps, numRuns, uint32(numMaps)*numRuns, true); ok {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX, key, detail)
+				}
+			}()
 		}
 
 		t.Log("\twhen multiple goroutines execute test loops")
 		{
-			numMaps, numRuns := uint16(10), uint32(1)
-			rc := assembleRunnerConfigForBatchTestLoop(
-				&runnerProperties{
-					numMaps:             numMaps,
-					numRuns:             numRuns,
-					cleanMapsPriorToRun: false,
-					sleepBetweenRuns:    sleepConfigDisabled,
-				},
-				sleepConfigDisabled,
-				sleepConfigDisabled,
-			)
-			ms := assembleTestMapStore(&testMapStoreBehavior{})
-			tl := assembleBatchTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+			func() {
+				defer resetGetOrAssemblePayloadTestSetup()
 
-			go tl.gatherer.Listen()
-			tl.run()
-			tl.gatherer.StopListen()
+				numMaps, numRuns := uint16(10), uint32(1)
+				rc := assembleRunnerConfigForBatchTestLoop(
+					&runnerProperties{
+						numMaps:             numMaps,
+						numRuns:             numRuns,
+						cleanMapsPriorToRun: false,
+						sleepBetweenRuns:    sleepConfigDisabled,
+					},
+					sleepConfigDisabled,
+					sleepConfigDisabled,
+				)
+				ms := assembleTestMapStore(&testMapStoreBehavior{})
+				tl := assembleBatchTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
 
-			waitForStatusGatheringDone(tl.gatherer)
+				go tl.gatherer.Listen()
+				tl.run()
+				tl.gatherer.StopListen()
 
-			expectedNumSetInvocations := len(theFellowship) * 10
-			expectedNumGetInvocations := len(theFellowship) * 10
-			expectedNumDestroyInvocations := 10
+				waitForStatusGatheringDone(tl.gatherer)
 
-			msg := "\t\texpected predictable invocations on map must have been executed"
+				expectedNumSetInvocations := len(theFellowship) * 10
+				expectedNumGetInvocations := len(theFellowship) * 10
+				expectedNumDestroyInvocations := 10
 
-			if expectedNumSetInvocations == ms.m.setInvocations &&
-				expectedNumGetInvocations == ms.m.getInvocations &&
-				expectedNumDestroyInvocations == ms.m.destroyInvocations {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX)
-			}
+				msg := "\t\texpected predictable invocations on map must have been executed"
 
-			msg = "\t\texpected invocations based on random element in test loop must have been executed"
+				if expectedNumSetInvocations == ms.m.setInvocations &&
+					expectedNumGetInvocations == ms.m.getInvocations &&
+					expectedNumDestroyInvocations == ms.m.destroyInvocations {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX)
+				}
 
-			expectedContainsKeyInvocations := expectedNumSetInvocations + ms.m.removeInvocations
-			if expectedContainsKeyInvocations == ms.m.containsKeyInvocations {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX)
-			}
+				msg = "\t\texpected invocations based on random element in test loop must have been executed"
 
-			msg = "\t\tvalues in test loop status must be correct"
+				expectedContainsKeyInvocations := expectedNumSetInvocations + ms.m.removeInvocations
+				if expectedContainsKeyInvocations == ms.m.containsKeyInvocations {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX)
+				}
 
-			if ok, key, detail := statusContainsExpectedValues(tl.gatherer.AssembleStatusCopy(), numMaps, numRuns, uint32(numMaps)*numRuns, true); ok {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX, key, detail)
-			}
+				msg = "\t\tvalues in test loop status must be correct"
+
+				if ok, key, detail := statusContainsExpectedValues(tl.gatherer.AssembleStatusCopy(), numMaps, numRuns, uint32(numMaps)*numRuns, true); ok {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX, key, detail)
+				}
+			}()
 		}
 
 		t.Log("\twhen get map yields error")
 		{
-			numMaps, numRuns := uint16(1), uint32(1)
-			rc := assembleRunnerConfigForBatchTestLoop(
-				&runnerProperties{
-					numMaps:             numMaps,
-					numRuns:             numRuns,
-					cleanMapsPriorToRun: false,
-					sleepBetweenRuns:    sleepConfigDisabled,
-				},
-				sleepConfigDisabled,
-				sleepConfigDisabled,
-			)
-			ms := assembleTestMapStore(&testMapStoreBehavior{returnErrorUponGetMap: true})
-			tl := assembleBatchTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+			func() {
+				defer resetGetOrAssemblePayloadTestSetup()
 
-			go tl.gatherer.Listen()
-			tl.run()
-			tl.gatherer.StopListen()
+				numMaps, numRuns := uint16(1), uint32(1)
+				rc := assembleRunnerConfigForBatchTestLoop(
+					&runnerProperties{
+						numMaps:             numMaps,
+						numRuns:             numRuns,
+						cleanMapsPriorToRun: false,
+						sleepBetweenRuns:    sleepConfigDisabled,
+					},
+					sleepConfigDisabled,
+					sleepConfigDisabled,
+				)
+				ms := assembleTestMapStore(&testMapStoreBehavior{returnErrorUponGetMap: true})
+				tl := assembleBatchTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
 
-			waitForStatusGatheringDone(tl.gatherer)
+				go tl.gatherer.Listen()
+				tl.run()
+				tl.gatherer.StopListen()
 
-			msg := "\t\tno invocations on map must have been attempted"
+				waitForStatusGatheringDone(tl.gatherer)
 
-			if ms.m.containsKeyInvocations == 0 &&
-				ms.m.setInvocations == 0 &&
-				ms.m.getInvocations == 0 &&
-				ms.m.removeInvocations == 0 &&
-				ms.m.destroyInvocations == 0 {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX)
-			}
+				msg := "\t\tno invocations on map must have been attempted"
 
-			msg = "\t\tvalues in test loop status must be correct"
+				if ms.m.containsKeyInvocations == 0 &&
+					ms.m.setInvocations == 0 &&
+					ms.m.getInvocations == 0 &&
+					ms.m.removeInvocations == 0 &&
+					ms.m.destroyInvocations == 0 {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX)
+				}
 
-			if ok, key, detail := statusContainsExpectedValues(tl.gatherer.AssembleStatusCopy(), numMaps, numRuns, uint32(numMaps)*numRuns, true); ok {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX, key, detail)
-			}
+				msg = "\t\tvalues in test loop status must be correct"
+
+				if ok, key, detail := statusContainsExpectedValues(tl.gatherer.AssembleStatusCopy(), numMaps, numRuns, uint32(numMaps)*numRuns, true); ok {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX, key, detail)
+				}
+			}()
 		}
 
 		t.Log("\twhen only one run is executed an error is thrown during read all")
 		{
-			numMaps, numRuns := uint16(1), uint32(1)
-			rc := assembleRunnerConfigForBatchTestLoop(
-				&runnerProperties{
-					numMaps:             numMaps,
-					numRuns:             numRuns,
-					cleanMapsPriorToRun: false,
-					sleepBetweenRuns:    sleepConfigDisabled,
-				},
-				sleepConfigDisabled,
-				sleepConfigDisabled,
-			)
-			ms := assembleTestMapStore(&testMapStoreBehavior{returnErrorUponGet: true})
-			tl := assembleBatchTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+			func() {
+				defer resetGetOrAssemblePayloadTestSetup()
 
-			go tl.gatherer.Listen()
-			tl.run()
-			tl.gatherer.StopListen()
+				numMaps, numRuns := uint16(1), uint32(1)
+				rc := assembleRunnerConfigForBatchTestLoop(
+					&runnerProperties{
+						numMaps:             numMaps,
+						numRuns:             numRuns,
+						cleanMapsPriorToRun: false,
+						sleepBetweenRuns:    sleepConfigDisabled,
+					},
+					sleepConfigDisabled,
+					sleepConfigDisabled,
+				)
+				ms := assembleTestMapStore(&testMapStoreBehavior{returnErrorUponGet: true})
+				tl := assembleBatchTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
 
-			waitForStatusGatheringDone(tl.gatherer)
+				go tl.gatherer.Listen()
+				tl.run()
+				tl.gatherer.StopListen()
 
-			msg := "\t\tno remove invocations must have been attempted"
+				waitForStatusGatheringDone(tl.gatherer)
 
-			if ms.m.removeInvocations == 0 {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX)
-			}
+				msg := "\t\tno remove invocations must have been attempted"
 
-			msg = "\t\tdata must remain in map since no remove was executed"
+				if ms.m.removeInvocations == 0 {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX)
+				}
 
-			if numElementsInSyncMap(ms.m.data) == len(theFellowship) {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX)
-			}
+				msg = "\t\tdata must remain in map since no remove was executed"
 
-			msg = "\t\tvalues in test loop status must be correct"
+				if numElementsInSyncMap(ms.m.data) == len(theFellowship) {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX)
+				}
 
-			expectedRuns := uint32(numMaps) * numRuns
-			if ok, key, detail := statusContainsExpectedValues(tl.gatherer.AssembleStatusCopy(), numMaps, numRuns, expectedRuns, true); ok {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX, key, detail)
-			}
+				msg = "\t\tvalues in test loop status must be correct"
+
+				expectedRuns := uint32(numMaps) * numRuns
+				if ok, key, detail := statusContainsExpectedValues(tl.gatherer.AssembleStatusCopy(), numMaps, numRuns, expectedRuns, true); ok {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX, key, detail)
+				}
+			}()
 		}
 
 		t.Log("\twhen no map goroutine is launched because the configured number of maps is zero")
@@ -2688,91 +2718,99 @@ func TestRunWithBatchTestLoop(t *testing.T) {
 		}
 		t.Log("\twhen sleep configs for sleep between runs and sleep between action batches are disabled")
 		{
-			scBetweenRuns := &sleepConfig{}
-			scBetweenActionBatches := &sleepConfig{}
-			rc := assembleRunnerConfigForBatchTestLoop(
-				&runnerProperties{
-					numMaps:             1,
-					numRuns:             20,
-					cleanMapsPriorToRun: false,
-					sleepBetweenRuns:    scBetweenRuns,
-				},
-				sleepConfigDisabled,
-				scBetweenActionBatches,
-			)
-			tl := assembleBatchTestLoop(uuid.New(), testSource, &testHzClientHandler{}, assembleTestMapStore(&testMapStoreBehavior{}), rc)
+			func() {
+				defer resetGetOrAssemblePayloadTestSetup()
 
-			numInvocationsBetweenRuns := 0
-			numInvocationsBetweenActionBatches := 0
-			sleepTimeFunc = func(sc *sleepConfig) int {
-				if sc == scBetweenRuns {
-					numInvocationsBetweenRuns++
-				} else if sc == scBetweenActionBatches {
-					numInvocationsBetweenActionBatches++
+				scBetweenRuns := &sleepConfig{}
+				scBetweenActionBatches := &sleepConfig{}
+				rc := assembleRunnerConfigForBatchTestLoop(
+					&runnerProperties{
+						numMaps:             1,
+						numRuns:             20,
+						cleanMapsPriorToRun: false,
+						sleepBetweenRuns:    scBetweenRuns,
+					},
+					sleepConfigDisabled,
+					scBetweenActionBatches,
+				)
+				tl := assembleBatchTestLoop(uuid.New(), testSource, &testHzClientHandler{}, assembleTestMapStore(&testMapStoreBehavior{}), rc)
+
+				numInvocationsBetweenRuns := 0
+				numInvocationsBetweenActionBatches := 0
+				sleepTimeFunc = func(sc *sleepConfig) int {
+					if sc == scBetweenRuns {
+						numInvocationsBetweenRuns++
+					} else if sc == scBetweenActionBatches {
+						numInvocationsBetweenActionBatches++
+					}
+					return 0
 				}
-				return 0
-			}
 
-			tl.run()
+				tl.run()
 
-			msg := "\t\tnumber of sleeps between runs must zero"
-			if numInvocationsBetweenRuns == 0 {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX)
-			}
+				msg := "\t\tnumber of sleeps between runs must zero"
+				if numInvocationsBetweenRuns == 0 {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX)
+				}
 
-			msg = "\t\tnumber of sleeps between action batches must be zero"
-			if numInvocationsBetweenActionBatches == 0 {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX)
-			}
+				msg = "\t\tnumber of sleeps between action batches must be zero"
+				if numInvocationsBetweenActionBatches == 0 {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX)
+				}
+			}()
 		}
 
 		t.Log("\twhen sleep configs for sleep between runs and sleep between action batches are enabled")
 		{
-			numRuns := uint32(20)
-			scBetweenRuns := &sleepConfig{enabled: true}
-			scBetweenActionsBatches := &sleepConfig{enabled: true}
-			rc := assembleRunnerConfigForBatchTestLoop(
-				&runnerProperties{
-					numMaps:             1,
-					numRuns:             numRuns,
-					cleanMapsPriorToRun: false,
-					sleepBetweenRuns:    scBetweenRuns,
-				},
-				sleepConfigDisabled,
-				scBetweenActionsBatches,
-			)
-			tl := assembleBatchTestLoop(uuid.New(), testSource, &testHzClientHandler{}, assembleTestMapStore(&testMapStoreBehavior{}), rc)
+			func() {
+				defer resetGetOrAssemblePayloadTestSetup()
 
-			numInvocationsBetweenRuns := uint32(0)
-			numInvocationsBetweenActionBatches := uint32(0)
-			sleepTimeFunc = func(sc *sleepConfig) int {
-				if sc == scBetweenRuns {
-					numInvocationsBetweenRuns++
-				} else if sc == scBetweenActionsBatches {
-					numInvocationsBetweenActionBatches++
+				numRuns := uint32(20)
+				scBetweenRuns := &sleepConfig{enabled: true}
+				scBetweenActionsBatches := &sleepConfig{enabled: true}
+				rc := assembleRunnerConfigForBatchTestLoop(
+					&runnerProperties{
+						numMaps:             1,
+						numRuns:             numRuns,
+						cleanMapsPriorToRun: false,
+						sleepBetweenRuns:    scBetweenRuns,
+					},
+					sleepConfigDisabled,
+					scBetweenActionsBatches,
+				)
+				tl := assembleBatchTestLoop(uuid.New(), testSource, &testHzClientHandler{}, assembleTestMapStore(&testMapStoreBehavior{}), rc)
+
+				numInvocationsBetweenRuns := uint32(0)
+				numInvocationsBetweenActionBatches := uint32(0)
+				sleepTimeFunc = func(sc *sleepConfig) int {
+					if sc == scBetweenRuns {
+						numInvocationsBetweenRuns++
+					} else if sc == scBetweenActionsBatches {
+						numInvocationsBetweenActionBatches++
+					}
+					return 0
 				}
-				return 0
-			}
 
-			tl.run()
+				tl.run()
 
-			msg := "\t\tnumber of sleeps between runs must be equal to number of runs"
-			if numInvocationsBetweenRuns == numRuns {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX)
-			}
+				msg := "\t\tnumber of sleeps between runs must be equal to number of runs"
+				if numInvocationsBetweenRuns == numRuns {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX)
+				}
 
-			msg = "\t\tnumber of sleeps between action batches must be equal to two times the number of runs"
-			if numInvocationsBetweenActionBatches == 2*numRuns {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX)
-			}
+				msg = "\t\tnumber of sleeps between action batches must be equal to two times the number of runs"
+				if numInvocationsBetweenActionBatches == 2*numRuns {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX)
+				}
+			}()
 		}
 	}
 
@@ -2784,288 +2822,311 @@ func TestIngestAll(t *testing.T) {
 	{
 		t.Log("\twhen target map does not contain key yet and set does not yield error")
 		{
-			getOrAssembleObservations = getOrAssemblePayloadFunctionObservations{}
+			func() {
+				defer resetGetOrAssemblePayloadTestSetup()
 
-			ms := assembleTestMapStore(&testMapStoreBehavior{})
-			rc := assembleRunnerConfigForBatchTestLoop(
-				&runnerProperties{
-					numMaps:             1,
-					numRuns:             9,
-					cleanMapsPriorToRun: false,
-					sleepBetweenRuns:    sleepConfigDisabled,
-				},
-				sleepConfigDisabled,
-				sleepConfigDisabled,
-			)
-			tl := assembleBatchTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+				ms := assembleTestMapStore(&testMapStoreBehavior{})
+				rc := assembleRunnerConfigForBatchTestLoop(
+					&runnerProperties{
+						numMaps:             1,
+						numRuns:             9,
+						cleanMapsPriorToRun: false,
+						sleepBetweenRuns:    sleepConfigDisabled,
+					},
+					sleepConfigDisabled,
+					sleepConfigDisabled,
+				)
+				tl := assembleBatchTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
 
-			statusRecord := map[statusKey]any{
-				statusKeyNumFailedInserts: 0,
-			}
-			err := tl.ingestAll(ms.m, "awesome-map", uint16(0))
+				statusRecord := map[statusKey]any{
+					statusKeyNumFailedInserts: 0,
+				}
+				err := tl.ingestAll(ms.m, "awesome-map", uint16(0))
 
-			msg := "\t\tno error must be returned"
-			if err == nil {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX, err)
-			}
+				msg := "\t\tno error must be returned"
+				if err == nil {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX, err)
+				}
 
-			msg = "\t\tnumber of contains key invocations must be equal to number of elements in source data"
-			expected := len(tl.tle.elements)
-			actual := ms.m.containsKeyInvocations
-			if expected == actual {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX, fmt.Sprintf("expected %d, got %d", expected, actual))
-			}
+				msg = "\t\tnumber of contains key invocations must be equal to number of elements in source data"
+				expected := len(tl.tle.elements)
+				actual := ms.m.containsKeyInvocations
+				if expected == actual {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX, fmt.Sprintf("expected %d, got %d", expected, actual))
+				}
 
-			msg = "\t\tnumber of set invocations must be equal to number of elements in source data, too"
-			actual = ms.m.setInvocations
-			if expected == actual {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX, fmt.Sprintf("expected %d, got %d", expected, actual))
-			}
+				msg = "\t\tnumber of set invocations must be equal to number of elements in source data, too"
+				actual = ms.m.setInvocations
+				if expected == actual {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX, fmt.Sprintf("expected %d, got %d", expected, actual))
+				}
 
-			msg = "\t\tstatus record must indicate there have been zero failed insert attempts"
-			expected = 0
-			actual = statusRecord[statusKeyNumFailedInserts].(int)
-			if expected == actual {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX, fmt.Sprintf("expected %d, got %d", expected, actual))
-			}
+				msg = "\t\tstatus record must indicate there have been zero failed insert attempts"
+				expected = 0
+				actual = statusRecord[statusKeyNumFailedInserts].(int)
+				if expected == actual {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX, fmt.Sprintf("expected %d, got %d", expected, actual))
+				}
 
-			msg = "\t\tnumber of get or assemble payload invocations must be equal to number of elements in source data"
-			if getOrAssembleObservations.numInvocations == len(tl.tle.elements) {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX, getOrAssembleObservations.numInvocations)
-			}
+				msg = "\t\tnumber of get or assemble payload invocations must be equal to number of elements in source data"
+				if getOrAssembleObservations.numInvocations == len(tl.tle.elements) {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX, getOrAssembleObservations.numInvocations)
+				}
+			}()
 		}
 		t.Log("\twhen target map contains all keys")
 		{
-			ms := assembleTestMapStore(&testMapStoreBehavior{})
-			rc := assembleRunnerConfigForBatchTestLoop(
-				&runnerProperties{
-					numMaps:             1,
-					numRuns:             9,
-					cleanMapsPriorToRun: false,
-					sleepBetweenRuns:    sleepConfigDisabled,
-				},
-				sleepConfigDisabled,
-				sleepConfigDisabled,
-			)
-			tl := assembleBatchTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
-			populateTestHzMapStore(&ms)
+			func() {
+				defer resetGetOrAssemblePayloadTestSetup()
 
-			statusRecord := map[statusKey]any{
-				statusKeyNumFailedInserts: 0,
-			}
-			err := tl.ingestAll(ms.m, "awesome-map", uint16(0))
-			msg := "\t\tno error must be returned"
+				ms := assembleTestMapStore(&testMapStoreBehavior{})
+				rc := assembleRunnerConfigForBatchTestLoop(
+					&runnerProperties{
+						numMaps:             1,
+						numRuns:             9,
+						cleanMapsPriorToRun: false,
+						sleepBetweenRuns:    sleepConfigDisabled,
+					},
+					sleepConfigDisabled,
+					sleepConfigDisabled,
+				)
+				tl := assembleBatchTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+				populateTestHzMapStore(&ms)
 
-			if err == nil {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX, err)
-			}
+				statusRecord := map[statusKey]any{
+					statusKeyNumFailedInserts: 0,
+				}
+				err := tl.ingestAll(ms.m, "awesome-map", uint16(0))
+				msg := "\t\tno error must be returned"
 
-			msg = "\t\tnumber of contains key invocations must be equal to number of elements in source data"
-			expected := len(theFellowship)
-			actual := ms.m.containsKeyInvocations
-			if expected == actual {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX, fmt.Sprintf("expected %d, got %d", expected, actual))
-			}
+				if err == nil {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX, err)
+				}
 
-			msg = "\t\tnumber of inserts must be zero"
-			expected = 0
-			actual = ms.m.setInvocations
-			if expected == actual {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX, fmt.Sprintf("expected %d, got %d", expected, actual))
-			}
+				msg = "\t\tnumber of contains key invocations must be equal to number of elements in source data"
+				expected := len(theFellowship)
+				actual := ms.m.containsKeyInvocations
+				if expected == actual {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX, fmt.Sprintf("expected %d, got %d", expected, actual))
+				}
 
-			msg = "\t\tstatus record must indicate zero failed inserts"
-			actual = statusRecord[statusKeyNumFailedInserts].(int)
-			if expected == actual {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX, fmt.Sprintf("expected %d, got %d", expected, actual))
-			}
+				msg = "\t\tnumber of inserts must be zero"
+				expected = 0
+				actual = ms.m.setInvocations
+				if expected == actual {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX, fmt.Sprintf("expected %d, got %d", expected, actual))
+				}
+
+				msg = "\t\tstatus record must indicate zero failed inserts"
+				actual = statusRecord[statusKeyNumFailedInserts].(int)
+				if expected == actual {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX, fmt.Sprintf("expected %d, got %d", expected, actual))
+				}
+			}()
 		}
 		t.Log("\twhen target map contains no keys and insert yields error")
 		{
-			ms := assembleTestMapStore(&testMapStoreBehavior{
-				returnErrorUponSet: true,
-			})
-			rc := assembleRunnerConfigForBatchTestLoop(
-				&runnerProperties{
-					numMaps:             1,
-					numRuns:             9,
-					cleanMapsPriorToRun: false,
-					sleepBetweenRuns:    sleepConfigDisabled,
-				},
-				sleepConfigDisabled,
-				sleepConfigDisabled,
-			)
-			tl := assembleBatchTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+			func() {
+				defer resetGetOrAssemblePayloadTestSetup()
 
-			go tl.gatherer.Listen()
-			err := tl.ingestAll(ms.m, "awesome-map", uint16(0))
-			tl.gatherer.StopListen()
+				ms := assembleTestMapStore(&testMapStoreBehavior{
+					returnErrorUponSet: true,
+				})
+				rc := assembleRunnerConfigForBatchTestLoop(
+					&runnerProperties{
+						numMaps:             1,
+						numRuns:             9,
+						cleanMapsPriorToRun: false,
+						sleepBetweenRuns:    sleepConfigDisabled,
+					},
+					sleepConfigDisabled,
+					sleepConfigDisabled,
+				)
+				tl := assembleBatchTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
 
-			msg := "\t\terror must be returned"
-			if err != nil {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX)
-			}
+				go tl.gatherer.Listen()
+				err := tl.ingestAll(ms.m, "awesome-map", uint16(0))
+				tl.gatherer.StopListen()
 
-			expected := 1
-			msg = fmt.Sprintf("\t\tnumber of contains key checks must be %d", expected)
-			actual := ms.m.containsKeyInvocations
-			if expected == actual {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX, fmt.Sprintf("expected %d, got %d", expected, actual))
-			}
+				msg := "\t\terror must be returned"
+				if err != nil {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX)
+				}
 
-			msg = fmt.Sprintf("\t\tnumber of inserts must be %d", expected)
-			actual = ms.m.setInvocations
-			if expected == actual {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX, fmt.Sprintf("expected %d, got %d", expected, actual))
-			}
+				expected := 1
+				msg = fmt.Sprintf("\t\tnumber of contains key checks must be %d", expected)
+				actual := ms.m.containsKeyInvocations
+				if expected == actual {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX, fmt.Sprintf("expected %d, got %d", expected, actual))
+				}
 
-			waitForStatusGatheringDone(tl.gatherer)
+				msg = fmt.Sprintf("\t\tnumber of inserts must be %d", expected)
+				actual = ms.m.setInvocations
+				if expected == actual {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX, fmt.Sprintf("expected %d, got %d", expected, actual))
+				}
 
-			msg = "\t\tstatus gatherer must have been informed about one failed insert attempt"
-			if ok, detail := expectedStatusPresent(tl.gatherer.AssembleStatusCopy(), statusKeyNumFailedInserts, 1); ok {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX, detail)
-			}
+				waitForStatusGatheringDone(tl.gatherer)
+
+				msg = "\t\tstatus gatherer must have been informed about one failed insert attempt"
+				if ok, detail := expectedStatusPresent(tl.gatherer.AssembleStatusCopy(), statusKeyNumFailedInserts, 1); ok {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX, detail)
+				}
+			}()
 
 		}
 		t.Log("\twhen contains key check yields error")
 		{
-			ms := assembleTestMapStore(&testMapStoreBehavior{
-				returnErrorUponContainsKey: true,
-			})
-			rc := assembleRunnerConfigForBatchTestLoop(
-				&runnerProperties{
-					numMaps:             1,
-					numRuns:             9,
-					cleanMapsPriorToRun: false,
-					sleepBetweenRuns:    sleepConfigDisabled,
-				},
-				sleepConfigDisabled,
-				sleepConfigDisabled,
-			)
-			tl := assembleBatchTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+			func() {
+				defer resetGetOrAssemblePayloadTestSetup()
 
-			go tl.gatherer.Listen()
-			err := tl.ingestAll(ms.m, "awesome-map", uint16(0))
-			tl.gatherer.StopListen()
+				ms := assembleTestMapStore(&testMapStoreBehavior{
+					returnErrorUponContainsKey: true,
+				})
+				rc := assembleRunnerConfigForBatchTestLoop(
+					&runnerProperties{
+						numMaps:             1,
+						numRuns:             9,
+						cleanMapsPriorToRun: false,
+						sleepBetweenRuns:    sleepConfigDisabled,
+					},
+					sleepConfigDisabled,
+					sleepConfigDisabled,
+				)
+				tl := assembleBatchTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
 
-			msg := "\t\terror must be returned"
-			if err != nil {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX)
-			}
+				go tl.gatherer.Listen()
+				err := tl.ingestAll(ms.m, "awesome-map", uint16(0))
+				tl.gatherer.StopListen()
 
-			msg = "\t\tstatus gatherer must have been informed about one failed contains key check"
-			waitForStatusGatheringDone(tl.gatherer)
-			if ok, detail := expectedStatusPresent(tl.gatherer.AssembleStatusCopy(), statusKeyNumFailedKeyChecks, 1); ok {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX, detail)
-			}
+				msg := "\t\terror must be returned"
+				if err != nil {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX)
+				}
+
+				msg = "\t\tstatus gatherer must have been informed about one failed contains key check"
+				waitForStatusGatheringDone(tl.gatherer)
+				if ok, detail := expectedStatusPresent(tl.gatherer.AssembleStatusCopy(), statusKeyNumFailedKeyChecks, 1); ok {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX, detail)
+				}
+			}()
+
 		}
 		t.Log("\twhen sleep after batch action is enabled")
 		{
-			ms := assembleTestMapStore(&testMapStoreBehavior{})
-			rc := assembleRunnerConfigForBatchTestLoop(
-				&runnerProperties{
-					numMaps:             1,
-					numRuns:             9,
-					cleanMapsPriorToRun: false,
-					sleepBetweenRuns:    sleepConfigDisabled,
-				},
-				&sleepConfig{
-					enabled: true,
-				},
-				sleepConfigDisabled,
-			)
-			tl := assembleBatchTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
-			s := &testSleeper{}
-			tl.s = s
+			func() {
+				defer resetGetOrAssemblePayloadTestSetup()
 
-			go tl.gatherer.Listen()
-			err := tl.ingestAll(ms.m, "awesome-map", uint16(0))
-			tl.gatherer.StopListen()
+				ms := assembleTestMapStore(&testMapStoreBehavior{})
+				rc := assembleRunnerConfigForBatchTestLoop(
+					&runnerProperties{
+						numMaps:             1,
+						numRuns:             9,
+						cleanMapsPriorToRun: false,
+						sleepBetweenRuns:    sleepConfigDisabled,
+					},
+					&sleepConfig{
+						enabled: true,
+					},
+					sleepConfigDisabled,
+				)
+				tl := assembleBatchTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+				s := &testSleeper{}
+				tl.s = s
 
-			msg := "\t\tno error must be returned"
-			if err == nil {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX, err)
-			}
+				go tl.gatherer.Listen()
+				err := tl.ingestAll(ms.m, "awesome-map", uint16(0))
+				tl.gatherer.StopListen()
 
-			msg = "\t\tsleeper must have been invoked"
-			if s.sleepInvoked {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX)
-			}
+				msg := "\t\tno error must be returned"
+				if err == nil {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX, err)
+				}
+
+				msg = "\t\tsleeper must have been invoked"
+				if s.sleepInvoked {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX)
+				}
+			}()
 		}
 		t.Log("\twhen invocation of get or assemble payload yields error")
 		{
-			getOrAssembleObservations = getOrAssemblePayloadFunctionObservations{}
-			getOrAssembleBehavior = getOrAssemblePayloadFunctionBehavior{returnError: true}
+			func() {
+				defer resetGetOrAssemblePayloadTestSetup()
 
-			ms := assembleTestMapStore(&testMapStoreBehavior{})
-			rc := assembleRunnerConfigForBatchTestLoop(
-				&runnerProperties{
-					numMaps:             1,
-					numRuns:             9,
-					cleanMapsPriorToRun: false,
-					sleepBetweenRuns:    sleepConfigDisabled,
-				},
-				sleepConfigDisabled,
-				sleepConfigDisabled,
-			)
-			tl := assembleBatchTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+				getOrAssembleBehavior = getOrAssemblePayloadFunctionBehavior{returnError: true}
 
-			err := tl.ingestAll(ms.m, "awesome-map", uint16(0))
+				ms := assembleTestMapStore(&testMapStoreBehavior{})
+				rc := assembleRunnerConfigForBatchTestLoop(
+					&runnerProperties{
+						numMaps:             1,
+						numRuns:             9,
+						cleanMapsPriorToRun: false,
+						sleepBetweenRuns:    sleepConfigDisabled,
+					},
+					sleepConfigDisabled,
+					sleepConfigDisabled,
+				)
+				tl := assembleBatchTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
 
-			msg := "\t\terror must be returned"
-			if errors.Is(err, getOrAssemblePayloadError) {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX)
-			}
+				err := tl.ingestAll(ms.m, "awesome-map", uint16(0))
 
-			msg = "\t\tget or assemble payload function must have been invoked only once"
-			if getOrAssembleObservations.numInvocations == 1 {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX, getOrAssembleObservations.numInvocations)
-			}
+				msg := "\t\terror must be returned"
+				if errors.Is(err, getOrAssemblePayloadError) {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX)
+				}
 
-			msg = "\t\tthere must have been no attempt of inserting a key-value pair into the target map"
-			if ms.m.setInvocations == 0 {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX)
-			}
+				msg = "\t\tget or assemble payload function must have been invoked only once"
+				if getOrAssembleObservations.numInvocations == 1 {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX, getOrAssembleObservations.numInvocations)
+				}
+
+				msg = "\t\tthere must have been no attempt of inserting a key-value pair into the target map"
+				if ms.m.setInvocations == 0 {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX)
+				}
+
+			}()
 		}
 	}
 
@@ -3371,6 +3432,13 @@ func TestRemoveSome(t *testing.T) {
 			}
 		}
 	}
+
+}
+
+func resetGetOrAssemblePayloadTestSetup() {
+
+	getOrAssembleObservations = getOrAssemblePayloadFunctionObservations{}
+	getOrAssembleBehavior = getOrAssemblePayloadFunctionBehavior{}
 
 }
 

--- a/resources/charts/hazeltest/Chart.yaml
+++ b/resources/charts/hazeltest/Chart.yaml
@@ -4,10 +4,6 @@ description: A Helm chart for deploying Hazeltest on Kubernetes
 
 type: application
 
-version: 1.2.1-0.14.1
+version: 1.2.1-0.15.0
 
-appVersion: "0.14.1"
-
-# Useful commands:
-# helm upgrade --install hazeltest . --namespace=hazelcastplatform
-# helm uninstall hazeltest --namespace=hazelcastplatform
+appVersion: "0.15.0"

--- a/resources/charts/hazeltest/values.yaml
+++ b/resources/charts/hazeltest/values.yaml
@@ -238,10 +238,18 @@ config:
       enabled: true
       numMaps: 10
       numEntriesPerMap: 1000
-      payloadSizeBytes: 100000
       appendMapIndexToMapName: true
       appendClientIdToMapName: false
       numRuns: 10000
+      payload:
+        fixedSize:
+          enabled: false
+          sizeBytes: 10000000
+        variableSize:
+          enabled: true
+          lowerBoundaryBytes: 15000
+          upperBoundaryBytes: 2000000
+          evaluateNewSizeAfterNumWriteActions: 100
       performPreRunClean:
         enabled: false
         errorBehavior: ignore

--- a/resources/charts/hazeltest/values.yaml
+++ b/resources/charts/hazeltest/values.yaml
@@ -237,7 +237,7 @@ config:
     load:
       enabled: true
       numMaps: 10
-      numEntriesPerMap: 1000
+      numEntriesPerMap: 10000
       appendMapIndexToMapName: true
       appendClientIdToMapName: false
       numRuns: 10000
@@ -247,8 +247,8 @@ config:
           sizeBytes: 10000000
         variableSize:
           enabled: true
-          lowerBoundaryBytes: 15000
-          upperBoundaryBytes: 2000000
+          lowerBoundaryBytes: 1000
+          upperBoundaryBytes: 10000
           evaluateNewSizeAfterNumWriteActions: 100
       performPreRunClean:
         enabled: false

--- a/resources/charts/hazeltest/values.yaml
+++ b/resources/charts/hazeltest/values.yaml
@@ -11,10 +11,10 @@ image:
 resources:
   requests:
     cpu: "200m"
-    memory: "500M"
+    memory: "250Mi"
   limits:
     cpu: "400m"
-    memory: "1G"
+    memory: "500Mi"
 
 startupArgs:
   - "-config-file=/data/config/custom-config.yaml"

--- a/status/gatherer.go
+++ b/status/gatherer.go
@@ -128,11 +128,10 @@ func (g *Gatherer) ListeningStopped() bool {
 
 func (g *Gatherer) insertSynchronously(u Update) {
 
-	// No-op for testing dev4 image
-	/*g.l.lock()
+	g.l.lock()
 	{
 		g.status[u.Key] = u.Value
 	}
-	g.l.unlock()*/
+	g.l.unlock()
 
 }

--- a/status/gatherer.go
+++ b/status/gatherer.go
@@ -128,10 +128,11 @@ func (g *Gatherer) ListeningStopped() bool {
 
 func (g *Gatherer) insertSynchronously(u Update) {
 
-	g.l.lock()
+	// No-op for testing dev4 image
+	/*g.l.lock()
 	{
 		g.status[u.Key] = u.Value
 	}
-	g.l.unlock()
+	g.l.unlock()*/
 
 }


### PR DESCRIPTION
Introduces the possibility for letting the map load runner generate variable-size payloads.

There are now two modes available on the map load runner for generating the payloads its test loop is going to write to maps in the Hazelcast cluster under test: fixed-size and variable-size mode. In terms of its payload generation, fixed-size mode is equivalent to payload generation in Hazeltest versions up to, and including, 0.14.1 -- the user simply specifies a payload size in bytes, which the map load runner's test loops will use to generate a payload to work with. 

The variable-size payload generation mode implemented in scope of #72 complements fixed-size generation mode in that it lets the user configure a lower and upper boundary defining the (inclusive) range of the size the generated payload will have. The user can also specify how many write operations the map load runner's test loop will do before re-evaluating the payload size from within that range. For example, if a user specifies a threshold of 100, the test loop will pick a size from within that range and generate payloads according to that size for 100 write operations, after which it will a new size from within the range, and use that for payload generation. (That being said, a user can also specify `1` as a re-evaluation threshold, which means that the size is evaluated after each write action, and that, given the configured range is large enough, it's unlikely two payloads generated and written the the target Hazelcast map will ever have the same size.)

Below is an excerpt from the application's `defaultConfig.yaml` file showing how to enable and configure variable-size payload generation mode, including documentation for each property:

```yaml
payload:
  fixedSize:
    # Whether to use a fixed-size payload. Enabling this will make the LoadRunner generate one string with a
    # size of 'sizeBytes' and pre-populate all load elements to be used in scope of the LoadRunner's
    # test loop. Hence, each key-value pair thus written will use the same string payload. Enabling fixed-size
    # payloads is equivalent to the LoadRunner's functionality in all versions of Hazeltest prior to 0.15.0.
    enabled: false
    sizeBytes: 10000000
  variableSize:
    # Whether to use variable-size payloads for the LoadRunner's test loop. If enabled, the properties below
    # are used to configure generating a string-based payload. The size of the generated payload will be within
    # the closed interval of [lower boundary, upper boundary], as specified by the two corresponding properties below.
    enabled: true
    # The lower boundary (inclusive) of the size, in bytes, to use for payload generation.
    lowerBoundaryBytes: 1000
    # The upper boundary (also inclusive) of the size, in bytes, to use for payload generation.
    upperBoundaryBytes: 10000
    # The steps after which the size of the payload should be re-evaluated. If set to 100, for example, an evaluated
    # size within the [lower, upper] boundary will be used for 100 write operations (emphasis on "write" operations;
    # a read or delete operation will not increase the counter). Set this to 1 if you would like the LoadRunner's test
    # loop to use a random size within the [lower, upper] boundary for each write operation.
    evaluateNewSizeAfterNumWriteActions: 100
```


Closes #72. 