### PR TITLE
Parallelize Work In Standalone State Cleaners

### DIFF
--- a/chaos/monkeys.go
+++ b/chaos/monkeys.go
@@ -145,7 +145,11 @@ func (m *memberKillerMonkey) init(a client.ConfigPropertyAssigner, s sleeper, c 
 func (m *memberKillerMonkey) causeChaos() {
 
 	defer m.g.StopListen()
-	go m.g.Listen()
+
+	listenReady := make(chan struct{})
+	go m.g.Listen(listenReady)
+	<-listenReady
+
 	m.insertInitialStatus()
 
 	m.appendState(start)

--- a/chaos/monkeys.go
+++ b/chaos/monkeys.go
@@ -25,7 +25,7 @@ type (
 		sleep(sc *sleepConfig, sf evaluateTimeToSleep)
 	}
 	monkey interface {
-		init(a client.ConfigPropertyAssigner, s sleeper, c hzMemberChooser, k hzMemberKiller, g *status.Gatherer,
+		init(a client.ConfigPropertyAssigner, s sleeper, c hzMemberChooser, k hzMemberKiller, g *status.DefaultGatherer,
 			readyFunc raiseReady, notReadyFunc raiseNotReady)
 		causeChaos()
 	}
@@ -38,7 +38,7 @@ type (
 		s                sleeper
 		chooser          hzMemberChooser
 		killer           hzMemberKiller
-		g                *status.Gatherer
+		g                *status.DefaultGatherer
 		readyFunc        raiseReady
 		notReadyFunc     raiseNotReady
 		numMembersKilled uint32
@@ -127,7 +127,7 @@ func (s *defaultSleeper) sleep(sc *sleepConfig, sf evaluateTimeToSleep) {
 }
 
 func (m *memberKillerMonkey) init(a client.ConfigPropertyAssigner, s sleeper, c hzMemberChooser, k hzMemberKiller,
-	g *status.Gatherer, readyFunc raiseReady, notReadyFunc raiseNotReady) {
+	g *status.DefaultGatherer, readyFunc raiseReady, notReadyFunc raiseNotReady) {
 
 	m.a = a
 	m.s = s

--- a/chaos/monkeys.go
+++ b/chaos/monkeys.go
@@ -25,7 +25,7 @@ type (
 		sleep(sc *sleepConfig, sf evaluateTimeToSleep)
 	}
 	monkey interface {
-		init(a client.ConfigPropertyAssigner, s sleeper, c hzMemberChooser, k hzMemberKiller, g *status.DefaultGatherer,
+		init(a client.ConfigPropertyAssigner, s sleeper, c hzMemberChooser, k hzMemberKiller, g status.Gatherer,
 			readyFunc raiseReady, notReadyFunc raiseNotReady)
 		causeChaos()
 	}
@@ -38,7 +38,7 @@ type (
 		s                sleeper
 		chooser          hzMemberChooser
 		killer           hzMemberKiller
-		g                *status.DefaultGatherer
+		g                status.Gatherer
 		readyFunc        raiseReady
 		notReadyFunc     raiseNotReady
 		numMembersKilled uint32
@@ -127,7 +127,7 @@ func (s *defaultSleeper) sleep(sc *sleepConfig, sf evaluateTimeToSleep) {
 }
 
 func (m *memberKillerMonkey) init(a client.ConfigPropertyAssigner, s sleeper, c hzMemberChooser, k hzMemberKiller,
-	g *status.DefaultGatherer, readyFunc raiseReady, notReadyFunc raiseNotReady) {
+	g status.Gatherer, readyFunc raiseReady, notReadyFunc raiseNotReady) {
 
 	m.a = a
 	m.s = s
@@ -160,7 +160,7 @@ func (m *memberKillerMonkey) causeChaos() {
 		return
 	}
 	m.appendState(populateConfigComplete)
-	m.g.Updates <- status.Update{Key: statusKeyNumRuns, Value: mc.numRuns}
+	m.g.Gather(status.Update{Key: statusKeyNumRuns, Value: mc.numRuns})
 
 	if !mc.enabled {
 		lp.LogChaosMonkeyEvent("member killer monkey not enabled -- won't run", log.InfoLevel)
@@ -215,14 +215,14 @@ func (m *memberKillerMonkey) causeChaos() {
 func (m *memberKillerMonkey) updateNumMembersKilled() {
 
 	m.numMembersKilled++
-	m.g.Updates <- status.Update{Key: statusKeyNumMembersKilled, Value: m.numMembersKilled}
+	m.g.Gather(status.Update{Key: statusKeyNumMembersKilled, Value: m.numMembersKilled})
 
 }
 
 func (m *memberKillerMonkey) insertInitialStatus() {
 
-	m.g.Updates <- status.Update{Key: statusKeyNumRuns, Value: uint32(0)}
-	m.g.Updates <- status.Update{Key: statusKeyNumMembersKilled, Value: uint32(0)}
+	m.g.Gather(status.Update{Key: statusKeyNumRuns, Value: uint32(0)})
+	m.g.Gather(status.Update{Key: statusKeyNumMembersKilled, Value: uint32(0)})
 
 }
 

--- a/chaos/monkeys_test.go
+++ b/chaos/monkeys_test.go
@@ -646,7 +646,7 @@ func TestPopulateConfig(t *testing.T) {
 
 }
 
-func waitForStatusGatheringDone(g *status.Gatherer) {
+func waitForStatusGatheringDone(g *status.DefaultGatherer) {
 
 	for {
 		if done := g.ListeningStopped(); done {

--- a/chaos/monkeys_test.go
+++ b/chaos/monkeys_test.go
@@ -646,7 +646,7 @@ func TestPopulateConfig(t *testing.T) {
 
 }
 
-func waitForStatusGatheringDone(g *status.DefaultGatherer) {
+func waitForStatusGatheringDone(g status.Gatherer) {
 
 	for {
 		if done := g.ListeningStopped(); done {

--- a/client/defaultConfig.yaml
+++ b/client/defaultConfig.yaml
@@ -99,6 +99,15 @@ stateCleaners:
       # When prefix usage has been enabled, this prefix will be used to search for maps to clean in the entire set of
       # maps available on the target Hazelcast cluster (except those maps whose name starts with two underscores).
       prefix: "ht_"
+    # The divisor to apply to the number of identified candidate data structures in order to calculate the number of
+    # workers to use for parallel cleaning. For example, if the cleaner has identified 2.000 maps in the target
+    # Hazelcast cluster that might be susceptible to cleaning and this divisor is set to 10, then the cleaner will
+    # spawn 200 workers.
+    # Note that "candidate data structure" doesn't necessarily mean the data structure in question is actually
+    # susceptible to cleaning -- this decision is made by each worker based on the clean again threshold configuration
+    # (see below). "Candidate data structure" therefore only means that the kind and name of the data structure make
+    # it a potential candidate for cleaning based on the configured prefix (see above).
+    parallelCleanNumDataStructuresDivisor: 10
     # Map cleaners across Hazeltest instances keep track of which payload maps they have cleaned at which timestamp.
     # This is the key to avoiding that a number of Hazeltest instances clean payload maps containing the state of
     # other instances in cases where payload map names are shared across these instances (which is the case for a
@@ -124,6 +133,7 @@ stateCleaners:
     prefix:
       enabled: true
       prefix: "ht_"
+    parallelCleanNumDataStructuresDivisor: 10
     cleanAgainThreshold:
       enabled: true
       thresholdMs: 30000

--- a/client/defaultConfig.yaml
+++ b/client/defaultConfig.yaml
@@ -107,6 +107,16 @@ stateCleaners:
     # susceptible to cleaning -- this decision is made by each worker based on the clean again threshold configuration
     # (see below). "Candidate data structure" therefore only means that the kind and name of the data structure make
     # it a potential candidate for cleaning based on the configured prefix (see above).
+    # Please keep in mind that the amount of CPU given to the Hazeltest instance running the state cleaner that will
+    # spawn the workers obviously limits how efficient the increase in parallelism can be -- for example, with a
+    # CPU limit of a mere 400m, increasing the parallelism level by having the state cleaner spawn more workers
+    # will not yield a tremendous decrease in the time it takes for the candidate data structures to be examined and,
+    # potentially, cleaned. To back this up with some numbers, here's the results of some measurements I took:
+    # 400m CPU limit, 2.000 maps, 1 worker (divisor: 2.000) --> 7.382ms
+    # 400m CPU limit, 2.000 maps, 200 workers (divisor: 10) --> 5.488ms
+    # Whereas:
+    # 1000m CPU limit, 2.000 maps, 1 worker (divisor: 2.000) --> 6.512ms
+    # 1000m CPU limit, 2.000 maps, 200 workers (divisor: 10) --> 1.391ms
     parallelCleanNumDataStructuresDivisor: 10
     # Map cleaners across Hazeltest instances keep track of which payload maps they have cleaned at which timestamp.
     # This is the key to avoiding that a number of Hazeltest instances clean payload maps containing the state of

--- a/maps/loadrunner.go
+++ b/maps/loadrunner.go
@@ -25,7 +25,7 @@ type (
 		hzClientHandler hazelcastwrapper.HzClientHandler
 		hzMapStore      hazelcastwrapper.MapStore
 		l               looper[loadElement]
-		gatherer        *status.DefaultGatherer
+		gatherer        status.Gatherer
 		providerFuncs   struct {
 			mapStore            newMapStoreFunc
 			loadElementTestLoop newLoadElementTestLoopFunc
@@ -176,7 +176,7 @@ func (r *loadRunner) runMapTests(ctx context.Context, hzCluster string, hzMember
 func (r *loadRunner) appendState(s runnerState) {
 
 	r.stateList = append(r.stateList, s)
-	r.gatherer.Updates <- status.Update{Key: string(statusKeyCurrentState), Value: string(s)}
+	r.gatherer.Gather(status.Update{Key: string(statusKeyCurrentState), Value: string(s)})
 
 }
 

--- a/maps/loadrunner.go
+++ b/maps/loadrunner.go
@@ -25,7 +25,7 @@ type (
 		hzClientHandler hazelcastwrapper.HzClientHandler
 		hzMapStore      hazelcastwrapper.MapStore
 		l               looper[loadElement]
-		gatherer        *status.Gatherer
+		gatherer        *status.DefaultGatherer
 		providerFuncs   struct {
 			mapStore            newMapStoreFunc
 			loadElementTestLoop newLoadElementTestLoopFunc
@@ -86,7 +86,7 @@ func (r *loadRunner) getSourceName() string {
 	return "loadRunner"
 }
 
-func (r *loadRunner) runMapTests(ctx context.Context, hzCluster string, hzMembers []string, gatherer *status.Gatherer) {
+func (r *loadRunner) runMapTests(ctx context.Context, hzCluster string, hzMembers []string, gatherer *status.DefaultGatherer) {
 
 	r.gatherer = gatherer
 	r.appendState(start)

--- a/maps/loadrunner_test.go
+++ b/maps/loadrunner_test.go
@@ -185,7 +185,7 @@ func TestRunLoadMapTests(t *testing.T) {
 			}
 
 			gatherer := status.NewGatherer()
-			go gatherer.Listen()
+			go gatherer.Listen(make(chan struct{}, 1))
 			r.runMapTests(context.TODO(), hzCluster, hzMembers, gatherer)
 			gatherer.StopListen()
 
@@ -222,7 +222,7 @@ func TestRunLoadMapTests(t *testing.T) {
 			r := loadRunner{assigner: assigner, stateList: []runnerState{}, hzClientHandler: ch}
 
 			gatherer := status.NewGatherer()
-			go gatherer.Listen()
+			go gatherer.Listen(make(chan struct{}, 1))
 
 			r.runMapTests(context.TODO(), hzCluster, hzMembers, gatherer)
 			gatherer.StopListen()
@@ -289,7 +289,7 @@ func TestRunLoadMapTests(t *testing.T) {
 			}
 
 			gatherer := status.NewGatherer()
-			go gatherer.Listen()
+			go gatherer.Listen(make(chan struct{}, 1))
 
 			r.runMapTests(context.TODO(), hzCluster, hzMembers, gatherer)
 			gatherer.StopListen()
@@ -377,7 +377,7 @@ func TestRunLoadMapTests(t *testing.T) {
 			}
 
 			gatherer := status.NewGatherer()
-			go gatherer.Listen()
+			go gatherer.Listen(make(chan struct{}, 1))
 			r.runMapTests(context.TODO(), hzCluster, hzMembers, gatherer)
 			gatherer.StopListen()
 
@@ -436,7 +436,7 @@ func TestRunLoadMapTests(t *testing.T) {
 			}
 
 			gatherer := status.NewGatherer()
-			go gatherer.Listen()
+			go gatherer.Listen(make(chan struct{}, 1))
 
 			numEntriesPerMap = 9
 			fixedPayloadSizeBytes = 3
@@ -534,7 +534,7 @@ func TestRunLoadMapTests(t *testing.T) {
 			}
 
 			gatherer := status.NewGatherer()
-			go gatherer.Listen()
+			go gatherer.Listen(make(chan struct{}, 1))
 
 			numEntriesPerMap = 9
 			fixedPayloadSizeBytes = 3
@@ -624,7 +624,7 @@ func TestRunLoadMapTests(t *testing.T) {
 			}
 
 			gatherer := status.NewGatherer()
-			go gatherer.Listen()
+			go gatherer.Listen(make(chan struct{}, 1))
 
 			numEntriesPerMap = 9
 			fixedPayloadSizeBytes = 3

--- a/maps/loadrunner_test.go
+++ b/maps/loadrunner_test.go
@@ -21,7 +21,7 @@ type (
 	}
 )
 
-func (d *testLoadTestLoop) init(tle *testLoopExecution[loadElement], _ sleeper, _ *status.DefaultGatherer) {
+func (d *testLoadTestLoop) init(tle *testLoopExecution[loadElement], _ sleeper, _ status.Gatherer) {
 	d.observations.numInitLooperInvocations++
 	d.assignedTestLoopExecution = tle
 }

--- a/maps/loadrunner_test.go
+++ b/maps/loadrunner_test.go
@@ -21,7 +21,7 @@ type (
 	}
 )
 
-func (d *testLoadTestLoop) init(tle *testLoopExecution[loadElement], _ sleeper, _ *status.Gatherer) {
+func (d *testLoadTestLoop) init(tle *testLoopExecution[loadElement], _ sleeper, _ *status.DefaultGatherer) {
 	d.observations.numInitLooperInvocations++
 	d.assignedTestLoopExecution = tle
 }

--- a/maps/maps_test.go
+++ b/maps/maps_test.go
@@ -110,7 +110,7 @@ var (
 	testMapOperationLock     sync.Mutex
 )
 
-func waitForStatusGatheringDone(g *status.DefaultGatherer) {
+func waitForStatusGatheringDone(g status.Gatherer) {
 
 	for {
 		if done := g.ListeningStopped(); done {
@@ -120,7 +120,7 @@ func waitForStatusGatheringDone(g *status.DefaultGatherer) {
 
 }
 
-func latestStatePresentInGatherer(g *status.DefaultGatherer, desiredState runnerState) bool {
+func latestStatePresentInGatherer(g status.Gatherer, desiredState runnerState) bool {
 
 	if value, ok := g.AssembleStatusCopy()[string(statusKeyCurrentState)]; ok && value == string(desiredState) {
 		return true

--- a/maps/maps_test.go
+++ b/maps/maps_test.go
@@ -110,7 +110,7 @@ var (
 	testMapOperationLock     sync.Mutex
 )
 
-func waitForStatusGatheringDone(g *status.Gatherer) {
+func waitForStatusGatheringDone(g *status.DefaultGatherer) {
 
 	for {
 		if done := g.ListeningStopped(); done {
@@ -120,7 +120,7 @@ func waitForStatusGatheringDone(g *status.Gatherer) {
 
 }
 
-func latestStatePresentInGatherer(g *status.Gatherer, desiredState runnerState) bool {
+func latestStatePresentInGatherer(g *status.DefaultGatherer, desiredState runnerState) bool {
 
 	if value, ok := g.AssembleStatusCopy()[string(statusKeyCurrentState)]; ok && value == string(desiredState) {
 		return true

--- a/maps/pokedexrunner.go
+++ b/maps/pokedexrunner.go
@@ -24,7 +24,7 @@ type (
 		hzMapStore      hazelcastwrapper.MapStore
 		hzClientHandler hazelcastwrapper.HzClientHandler
 		l               looper[pokemon]
-		gatherer        *status.DefaultGatherer
+		gatherer        status.Gatherer
 		providerFuncs   struct {
 			mapStore        newMapStoreFunc
 			pokemonTestLoop newPokemonTestLoopFunc
@@ -169,7 +169,7 @@ func (r *pokedexRunner) runMapTests(ctx context.Context, hzCluster string, hzMem
 func (r *pokedexRunner) appendState(s runnerState) {
 
 	r.stateList = append(r.stateList, s)
-	r.gatherer.Updates <- status.Update{Key: string(statusKeyCurrentState), Value: string(s)}
+	r.gatherer.Gather(status.Update{Key: string(statusKeyCurrentState), Value: string(s)})
 
 }
 

--- a/maps/pokedexrunner.go
+++ b/maps/pokedexrunner.go
@@ -24,7 +24,7 @@ type (
 		hzMapStore      hazelcastwrapper.MapStore
 		hzClientHandler hazelcastwrapper.HzClientHandler
 		l               looper[pokemon]
-		gatherer        *status.Gatherer
+		gatherer        *status.DefaultGatherer
 		providerFuncs   struct {
 			mapStore        newMapStoreFunc
 			pokemonTestLoop newPokemonTestLoopFunc
@@ -95,7 +95,7 @@ func (r *pokedexRunner) getSourceName() string {
 	return "pokedexRunner"
 }
 
-func (r *pokedexRunner) runMapTests(ctx context.Context, hzCluster string, hzMembers []string, gatherer *status.Gatherer) {
+func (r *pokedexRunner) runMapTests(ctx context.Context, hzCluster string, hzMembers []string, gatherer *status.DefaultGatherer) {
 
 	r.gatherer = gatherer
 	r.appendState(start)

--- a/maps/pokedexrunner_test.go
+++ b/maps/pokedexrunner_test.go
@@ -9,7 +9,7 @@ import (
 
 type testPokedexTestLoop struct{}
 
-func (d testPokedexTestLoop) init(_ *testLoopExecution[pokemon], _ sleeper, _ *status.Gatherer) {
+func (d testPokedexTestLoop) init(_ *testLoopExecution[pokemon], _ sleeper, _ *status.DefaultGatherer) {
 	// No-op
 }
 

--- a/maps/pokedexrunner_test.go
+++ b/maps/pokedexrunner_test.go
@@ -102,7 +102,7 @@ func TestRunPokedexMapTests(t *testing.T) {
 
 			gatherer := status.NewGatherer()
 
-			go gatherer.Listen()
+			go gatherer.Listen(make(chan struct{}, 1))
 			r.runMapTests(context.TODO(), hzCluster, hzMembers, gatherer)
 			gatherer.StopListen()
 
@@ -158,7 +158,7 @@ func TestRunPokedexMapTests(t *testing.T) {
 			}
 
 			gatherer := status.NewGatherer()
-			go gatherer.Listen()
+			go gatherer.Listen(make(chan struct{}, 1))
 
 			r.runMapTests(context.TODO(), hzCluster, hzMembers, gatherer)
 			gatherer.StopListen()
@@ -219,7 +219,7 @@ func TestRunPokedexMapTests(t *testing.T) {
 			}
 
 			gatherer := status.NewGatherer()
-			go gatherer.Listen()
+			go gatherer.Listen(make(chan struct{}, 1))
 
 			r.runMapTests(context.TODO(), hzCluster, hzMembers, gatherer)
 			gatherer.StopListen()

--- a/maps/pokedexrunner_test.go
+++ b/maps/pokedexrunner_test.go
@@ -9,7 +9,7 @@ import (
 
 type testPokedexTestLoop struct{}
 
-func (d testPokedexTestLoop) init(_ *testLoopExecution[pokemon], _ sleeper, _ *status.DefaultGatherer) {
+func (d testPokedexTestLoop) init(_ *testLoopExecution[pokemon], _ sleeper, _ status.Gatherer) {
 	// No-op
 }
 

--- a/maps/runner.go
+++ b/maps/runner.go
@@ -547,7 +547,10 @@ func (t *MapTester) TestMaps() {
 			defer wg.Done()
 
 			gatherer := status.NewGatherer()
-			go gatherer.Listen()
+			listenReady := make(chan struct{})
+			go gatherer.Listen(listenReady)
+			<-listenReady
+
 			defer gatherer.StopListen()
 
 			rn := runners[i]

--- a/maps/runner.go
+++ b/maps/runner.go
@@ -17,7 +17,7 @@ type (
 	runnerLoopType string
 	runner         interface {
 		getSourceName() string
-		runMapTests(ctx context.Context, hzCluster string, hzMembers []string, gatherer *status.Gatherer)
+		runMapTests(ctx context.Context, hzCluster string, hzMembers []string, gatherer *status.DefaultGatherer)
 	}
 	runnerConfig struct {
 		enabled                 bool

--- a/maps/testloop.go
+++ b/maps/testloop.go
@@ -23,11 +23,11 @@ type (
 	getElementIdFunc         func(element any) string
 	getOrAssemblePayloadFunc func(mapName string, mapNumber uint16, element any) (any, error)
 	looper[t any]            interface {
-		init(lc *testLoopExecution[t], s sleeper, gatherer *status.Gatherer)
+		init(lc *testLoopExecution[t], s sleeper, gatherer *status.DefaultGatherer)
 		run()
 	}
 	counterTracker interface {
-		init(gatherer *status.Gatherer)
+		init(gatherer *status.DefaultGatherer)
 		increaseCounter(sk statusKey)
 	}
 	sleeper interface {
@@ -39,7 +39,7 @@ type (
 type (
 	batchTestLoop[t any] struct {
 		tle      *testLoopExecution[t]
-		gatherer *status.Gatherer
+		gatherer *status.DefaultGatherer
 		ct       counterTracker
 		s        sleeper
 	}
@@ -54,7 +54,7 @@ type (
 	}
 	boundaryTestLoop[t any] struct {
 		tle      *testLoopExecution[t]
-		gatherer *status.Gatherer
+		gatherer *status.DefaultGatherer
 		s        sleeper
 		ct       counterTracker
 	}
@@ -74,7 +74,7 @@ type (
 	mapTestLoopCountersTracker struct {
 		counters map[statusKey]uint64
 		l        sync.Mutex
-		gatherer *status.Gatherer
+		gatherer *status.DefaultGatherer
 	}
 )
 
@@ -124,7 +124,7 @@ var (
 	counters = []statusKey{statusKeyNumFailedInserts, statusKeyNumFailedReads, statusKeyNumNilReads, statusKeyNumFailedRemoves, statusKeyNumFailedKeyChecks}
 )
 
-func (ct *mapTestLoopCountersTracker) init(gatherer *status.Gatherer) {
+func (ct *mapTestLoopCountersTracker) init(gatherer *status.DefaultGatherer) {
 	ct.gatherer = gatherer
 
 	ct.counters = make(map[statusKey]uint64)
@@ -150,7 +150,7 @@ func (ct *mapTestLoopCountersTracker) increaseCounter(sk statusKey) {
 
 }
 
-func (l *boundaryTestLoop[t]) init(tle *testLoopExecution[t], s sleeper, gatherer *status.Gatherer) {
+func (l *boundaryTestLoop[t]) init(tle *testLoopExecution[t], s sleeper, gatherer *status.DefaultGatherer) {
 	l.tle = tle
 	l.s = s
 	l.gatherer = gatherer
@@ -514,7 +514,7 @@ func (l *boundaryTestLoop[t]) checkForModeChange(upperBoundary, lowerBoundary fl
 
 }
 
-func (l *batchTestLoop[t]) init(tle *testLoopExecution[t], s sleeper, gatherer *status.Gatherer) {
+func (l *batchTestLoop[t]) init(tle *testLoopExecution[t], s sleeper, gatherer *status.DefaultGatherer) {
 	l.tle = tle
 	l.s = s
 	l.gatherer = gatherer
@@ -526,7 +526,7 @@ func (l *batchTestLoop[t]) init(tle *testLoopExecution[t], s sleeper, gatherer *
 }
 
 func runWrapper[t any](tle *testLoopExecution[t],
-	gatherer *status.Gatherer,
+	gatherer *status.DefaultGatherer,
 	assembleMapNameFunc func(*runnerConfig, uint16) string,
 	runFunc func(hazelcastwrapper.Map, string, uint16)) {
 

--- a/maps/testloop.go
+++ b/maps/testloop.go
@@ -576,7 +576,7 @@ func runWrapper[t any](tle *testLoopExecution[t],
 					lp.LogMapRunnerEvent("pre-run map eviction enabled, but encountered uninitialized state cleaner -- won't start test run for this map", tle.runnerName, log.ErrorLevel)
 					return
 				}
-				if numCleanedItems, err := stateCleaner.Clean(mapName); err != nil {
+				if scResult := stateCleaner.Clean(mapName); scResult.Err != nil {
 					configuredErrorBehavior := tle.runnerConfig.preRunClean.errorBehavior
 					if state.Ignore == tle.runnerConfig.preRunClean.errorBehavior {
 						lp.LogMapRunnerEvent(fmt.Sprintf("encountered error upon attempt to clean single map '%s' in scope of pre-run eviction, but error behavior is '%s', so test loop will commence: %v", mapName, configuredErrorBehavior, err), tle.runnerName, log.WarnLevel)
@@ -584,8 +584,8 @@ func runWrapper[t any](tle *testLoopExecution[t],
 						lp.LogMapRunnerEvent(fmt.Sprintf("encountered error upon attempt to clean single map '%s' in scope of pre-run eviction and error behavior is '%s' -- won't start test run for this map: %v", mapName, configuredErrorBehavior, err), tle.runnerName, log.ErrorLevel)
 						return
 					}
-				} else if numCleanedItems > 0 {
-					lp.LogMapRunnerEvent(fmt.Sprintf("successfully cleaned %d items from map '%s'", numCleanedItems, mapName), tle.runnerName, log.InfoLevel)
+				} else if scResult.NumCleanedItems > 0 {
+					lp.LogMapRunnerEvent(fmt.Sprintf("successfully cleaned %d items from map '%s'", scResult.NumCleanedItems, mapName), tle.runnerName, log.InfoLevel)
 				} else {
 					lp.LogMapRunnerEvent(fmt.Sprintf("payload map '%s' either didn't contain elements to be cleaned, or wasn't susceptible to cleaning yet", mapName), tle.runnerName, log.InfoLevel)
 				}

--- a/maps/testloop_test.go
+++ b/maps/testloop_test.go
@@ -89,15 +89,15 @@ func (b *testSingleMapCleanerBuilder) Build(_ context.Context, _ hazelcastwrappe
 
 }
 
-func (c *testSingleMapCleaner) Clean(_ string) (int, error) {
+func (c *testSingleMapCleaner) Clean(_ string) state.SingleCleanResult {
 
 	c.observations.cleanInvocations++
 
 	if c.behavior.returnErrorUponClean {
-		return 0, fmt.Errorf("something somewhere went terribly wrong")
+		return state.SingleCleanResult{Err: fmt.Errorf("something somewhere went terribly wrong")}
 	}
 
-	return c.behavior.numElementsCleanedReturnValue, nil
+	return state.SingleCleanResult{NumCleanedItems: c.behavior.numElementsCleanedReturnValue}
 
 }
 

--- a/maps/testloop_test.go
+++ b/maps/testloop_test.go
@@ -260,7 +260,8 @@ func TestMapTestLoopCountersTrackerIncreaseCounter(t *testing.T) {
 					}
 
 					msg = "\t\t\tcorresponding update must have been sent to status gatherer"
-					update := <-ct.gatherer.Updates
+					g := ct.gatherer.(*status.DefaultGatherer)
+					update := <-g.Updates
 					if update.Key == string(v) && update.Value == uint64(1) {
 						t.Log(msg, checkMark, v)
 					} else {

--- a/maps/testloop_test.go
+++ b/maps/testloop_test.go
@@ -198,7 +198,7 @@ func TestMapTestLoopCountersTrackerInit(t *testing.T) {
 			ct := &mapTestLoopCountersTracker{}
 			g := status.NewGatherer()
 
-			go g.Listen()
+			go g.Listen(make(chan struct{}, 1))
 			ct.init(g)
 			g.StopListen()
 
@@ -277,7 +277,7 @@ func TestMapTestLoopCountersTrackerIncreaseCounter(t *testing.T) {
 				l:        sync.Mutex{},
 				gatherer: status.NewGatherer(),
 			}
-			go ct.gatherer.Listen()
+			go ct.gatherer.Listen(make(chan struct{}, 1))
 			ct.counters[statusKeyNumFailedInserts] = 0
 			numInvokingGoroutines := 100
 			for i := 0; i < numInvokingGoroutines; i++ {
@@ -565,7 +565,7 @@ func TestRunWrapper(t *testing.T) {
 			)
 			ms := assembleTestMapStore(&testMapStoreBehavior{})
 			tl := assembleBoundaryTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
-			go tl.gatherer.Listen()
+			go tl.gatherer.Listen(make(chan struct{}, 1))
 			runWrapper(tl.tle, tl.gatherer, func(config *runnerConfig, u uint16) string {
 				return "banana"
 			}, func(h hazelcastwrapper.Map, s string, u uint16) {
@@ -626,7 +626,7 @@ func TestRunWrapper(t *testing.T) {
 			}
 			tl.tle.stateCleanerBuilder = &testSingleMapCleanerBuilder{mapCleanerToReturn: cleaner}
 
-			go tl.gatherer.Listen()
+			go tl.gatherer.Listen(make(chan struct{}, 1))
 
 			runFuncCalled := false
 			runWrapper(tl.tle, tl.gatherer, func(config *runnerConfig, u uint16) string {
@@ -681,7 +681,7 @@ func TestRunWrapper(t *testing.T) {
 
 				populateTestHzMapStore(defaultTestMapName, defaultTestMapNumber, &ms)
 
-				go tl.gatherer.Listen()
+				go tl.gatherer.Listen(make(chan struct{}, 1))
 				runFuncCalled := false
 				runWrapper(tl.tle, tl.gatherer, func(config *runnerConfig, u uint16) string {
 					return "banana"
@@ -778,7 +778,7 @@ func TestRunWrapper(t *testing.T) {
 
 				populateTestHzMapStore(defaultTestMapName, defaultTestMapNumber, &ms)
 
-				go tl.gatherer.Listen()
+				go tl.gatherer.Listen(make(chan struct{}, 1))
 				runFuncCalled := false
 				runWrapper(tl.tle, tl.gatherer, func(config *runnerConfig, u uint16) string {
 					return "banana"
@@ -835,7 +835,7 @@ func TestExecuteMapAction(t *testing.T) {
 
 					mapNumber := 0
 					mapName := fmt.Sprintf("%s-%s-%d", rc.mapPrefix, rc.mapBaseName, mapNumber)
-					go tl.gatherer.Listen()
+					go tl.gatherer.Listen(make(chan struct{}, 1))
 					err := tl.executeMapAction(ms.m, mapName, uint16(mapNumber), theFellowship[0], action)
 					tl.gatherer.StopListen()
 
@@ -908,7 +908,7 @@ func TestExecuteMapAction(t *testing.T) {
 					)
 					tl := assembleBoundaryTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
 
-					go tl.gatherer.Listen()
+					go tl.gatherer.Listen(make(chan struct{}, 1))
 					err := tl.executeMapAction(ms.m, "awesome-map-name", 0, theFellowship[0], insert)
 					tl.gatherer.StopListen()
 
@@ -1009,7 +1009,7 @@ func TestExecuteMapAction(t *testing.T) {
 
 					mapNumber := 0
 					mapName := fmt.Sprintf("%s-%s-%d", rc.mapPrefix, rc.mapBaseName, mapNumber)
-					go tl.gatherer.Listen()
+					go tl.gatherer.Listen(make(chan struct{}, 1))
 					err := tl.executeMapAction(ms.m, mapName, uint16(mapNumber), theFellowship[0], action)
 					tl.gatherer.StopListen()
 
@@ -1056,7 +1056,7 @@ func TestExecuteMapAction(t *testing.T) {
 					ms := assembleTestMapStore(&testMapStoreBehavior{})
 					tl := assembleBoundaryTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
 
-					go tl.gatherer.Listen()
+					go tl.gatherer.Listen(make(chan struct{}, 1))
 					err := tl.executeMapAction(ms.m, "my-map-name", uint16(0), theFellowship[0], remove)
 					tl.gatherer.StopListen()
 
@@ -1116,7 +1116,7 @@ func TestExecuteMapAction(t *testing.T) {
 
 				populateTestHzMapStore(defaultTestMapName, defaultTestMapNumber, &ms)
 
-				go tl.gatherer.Listen()
+				go tl.gatherer.Listen(make(chan struct{}, 1))
 				err := tl.executeMapAction(ms.m, "my-map-name", uint16(0), theFellowship[0], remove)
 				tl.gatherer.StopListen()
 
@@ -1213,7 +1213,7 @@ func TestExecuteMapAction(t *testing.T) {
 				ms := assembleTestMapStore(&testMapStoreBehavior{})
 				tl := assembleBoundaryTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
 
-				go tl.gatherer.Listen()
+				go tl.gatherer.Listen(make(chan struct{}, 1))
 				err := tl.executeMapAction(ms.m, "my-map-name", uint16(0), theFellowship[0], read)
 				tl.gatherer.StopListen()
 
@@ -1266,7 +1266,7 @@ func TestExecuteMapAction(t *testing.T) {
 
 				populateTestHzMapStore(defaultTestMapName, defaultTestMapNumber, &ms)
 
-				go tl.gatherer.Listen()
+				go tl.gatherer.Listen(make(chan struct{}, 1))
 				err := tl.executeMapAction(ms.m, "my-map-name", uint16(0), theFellowship[0], read)
 				tl.gatherer.StopListen()
 
@@ -2576,7 +2576,7 @@ func TestRunOperationChain(t *testing.T) {
 
 				ac := &actionCache{}
 				kc := map[string]string{}
-				go tl.gatherer.Listen()
+				go tl.gatherer.Listen(make(chan struct{}, 1))
 
 				mapName := "awesome-map"
 				mapNumber := uint16(12)
@@ -2644,7 +2644,7 @@ func TestRunOperationChain(t *testing.T) {
 
 				ac := &actionCache{}
 				kc := map[string]string{}
-				go tl.gatherer.Listen()
+				go tl.gatherer.Listen(make(chan struct{}, 1))
 
 				availableForInsertion := make(map[string]string, len(theFellowship))
 				for i := 0; i < len(theFellowship); i++ {
@@ -2721,7 +2721,7 @@ func TestRunWithBatchTestLoop(t *testing.T) {
 				)
 				tl := assembleBatchTestLoop(id, testSource, &testHzClientHandler{}, ms, rc)
 
-				go tl.gatherer.Listen()
+				go tl.gatherer.Listen(make(chan struct{}, 1))
 				tl.run()
 				tl.gatherer.StopListen()
 
@@ -2779,7 +2779,7 @@ func TestRunWithBatchTestLoop(t *testing.T) {
 				ms := assembleTestMapStore(&testMapStoreBehavior{})
 				tl := assembleBatchTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
 
-				go tl.gatherer.Listen()
+				go tl.gatherer.Listen(make(chan struct{}, 1))
 				tl.run()
 				tl.gatherer.StopListen()
 
@@ -2837,7 +2837,7 @@ func TestRunWithBatchTestLoop(t *testing.T) {
 				ms := assembleTestMapStore(&testMapStoreBehavior{returnErrorUponGetMap: true})
 				tl := assembleBatchTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
 
-				go tl.gatherer.Listen()
+				go tl.gatherer.Listen(make(chan struct{}, 1))
 				tl.run()
 				tl.gatherer.StopListen()
 
@@ -2884,7 +2884,7 @@ func TestRunWithBatchTestLoop(t *testing.T) {
 				ms := assembleTestMapStore(&testMapStoreBehavior{returnErrorUponGet: true})
 				tl := assembleBatchTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
 
-				go tl.gatherer.Listen()
+				go tl.gatherer.Listen(make(chan struct{}, 1))
 				tl.run()
 				tl.gatherer.StopListen()
 
@@ -2934,7 +2934,7 @@ func TestRunWithBatchTestLoop(t *testing.T) {
 			)
 			tl := assembleBatchTestLoop(id, testSource, &testHzClientHandler{}, ms, rc)
 
-			go tl.gatherer.Listen()
+			go tl.gatherer.Listen(make(chan struct{}, 1))
 			tl.run()
 			tl.gatherer.StopListen()
 
@@ -3194,7 +3194,7 @@ func TestIngestAll(t *testing.T) {
 				)
 				tl := assembleBatchTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
 
-				go tl.gatherer.Listen()
+				go tl.gatherer.Listen(make(chan struct{}, 1))
 				err := tl.ingestAll(ms.m, "awesome-map", uint16(0))
 				tl.gatherer.StopListen()
 
@@ -3253,7 +3253,7 @@ func TestIngestAll(t *testing.T) {
 				)
 				tl := assembleBatchTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
 
-				go tl.gatherer.Listen()
+				go tl.gatherer.Listen(make(chan struct{}, 1))
 				err := tl.ingestAll(ms.m, "awesome-map", uint16(0))
 				tl.gatherer.StopListen()
 
@@ -3296,7 +3296,7 @@ func TestIngestAll(t *testing.T) {
 				s := &testSleeper{}
 				tl.s = s
 
-				go tl.gatherer.Listen()
+				go tl.gatherer.Listen(make(chan struct{}, 1))
 				err := tl.ingestAll(ms.m, "awesome-map", uint16(0))
 				tl.gatherer.StopListen()
 
@@ -3384,7 +3384,7 @@ func TestReadAll(t *testing.T) {
 			tl := assembleBatchTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
 			populateTestHzMapStore(defaultTestMapName, defaultTestMapNumber, &ms)
 
-			go tl.gatherer.Listen()
+			go tl.gatherer.Listen(make(chan struct{}, 1))
 			err := tl.readAll(ms.m, defaultTestMapName, defaultTestMapNumber)
 			tl.gatherer.StopListen()
 
@@ -3432,7 +3432,7 @@ func TestReadAll(t *testing.T) {
 			)
 			tl := assembleBatchTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
 
-			go tl.gatherer.Listen()
+			go tl.gatherer.Listen(make(chan struct{}, 1))
 			err := tl.readAll(ms.m, testMapBaseName, 0)
 			tl.gatherer.StopListen()
 
@@ -3471,7 +3471,7 @@ func TestReadAll(t *testing.T) {
 
 			ms.m.data.Store(assembleMapKey("awesome-map", 0, "legolas"), nil)
 
-			go tl.gatherer.Listen()
+			go tl.gatherer.Listen(make(chan struct{}, 1))
 			err := tl.readAll(ms.m, testMapBaseName, 0)
 			tl.gatherer.StopListen()
 
@@ -3522,7 +3522,7 @@ func TestReadAll(t *testing.T) {
 			s := &testSleeper{}
 			tl.s = s
 
-			go tl.gatherer.Listen()
+			go tl.gatherer.Listen(make(chan struct{}, 1))
 			err := tl.readAll(ms.m, defaultTestMapName, defaultTestMapNumber)
 			tl.gatherer.StopListen()
 
@@ -3604,7 +3604,7 @@ func TestRemoveSome(t *testing.T) {
 
 			populateTestHzMapStore(defaultTestMapName, defaultTestMapNumber, &ms)
 
-			go tl.gatherer.Listen()
+			go tl.gatherer.Listen(make(chan struct{}, 1))
 			err := tl.removeSome(ms.m, defaultTestMapName, defaultTestMapNumber)
 			tl.gatherer.StopListen()
 
@@ -3645,7 +3645,7 @@ func TestRemoveSome(t *testing.T) {
 			s := &testSleeper{}
 			tl.s = s
 
-			go tl.gatherer.Listen()
+			go tl.gatherer.Listen(make(chan struct{}, 1))
 			err := tl.removeSome(ms.m, defaultTestMapName, defaultTestMapNumber)
 			tl.gatherer.StopListen()
 

--- a/queues/loadrunner.go
+++ b/queues/loadrunner.go
@@ -22,7 +22,7 @@ type (
 		hzClientHandler hazelcastwrapper.HzClientHandler
 		hzQueueStore    hazelcastwrapper.QueueStore
 		l               looper[loadElement]
-		gatherer        *status.Gatherer
+		gatherer        *status.DefaultGatherer
 	}
 	loadElement struct {
 		Payload string
@@ -50,7 +50,7 @@ func (r *loadRunner) getSourceName() string {
 	return r.source
 }
 
-func (r *loadRunner) runQueueTests(hzCluster string, hzMembers []string, gatherer *status.Gatherer, storeFunc initQueueStoreFunc) {
+func (r *loadRunner) runQueueTests(hzCluster string, hzMembers []string, gatherer *status.DefaultGatherer, storeFunc initQueueStoreFunc) {
 
 	r.gatherer = gatherer
 	r.appendState(start)

--- a/queues/loadrunner.go
+++ b/queues/loadrunner.go
@@ -22,7 +22,7 @@ type (
 		hzClientHandler hazelcastwrapper.HzClientHandler
 		hzQueueStore    hazelcastwrapper.QueueStore
 		l               looper[loadElement]
-		gatherer        *status.DefaultGatherer
+		gatherer        status.Gatherer
 	}
 	loadElement struct {
 		Payload string
@@ -50,7 +50,7 @@ func (r *loadRunner) getSourceName() string {
 	return r.source
 }
 
-func (r *loadRunner) runQueueTests(hzCluster string, hzMembers []string, gatherer *status.DefaultGatherer, storeFunc initQueueStoreFunc) {
+func (r *loadRunner) runQueueTests(hzCluster string, hzMembers []string, gatherer status.Gatherer, storeFunc initQueueStoreFunc) {
 
 	r.gatherer = gatherer
 	r.appendState(start)
@@ -100,7 +100,7 @@ func (r *loadRunner) runQueueTests(hzCluster string, hzMembers []string, gathere
 func (r *loadRunner) appendState(s state) {
 
 	r.stateList = append(r.stateList, s)
-	r.gatherer.Updates <- status.Update{Key: string(statusKeyCurrentState), Value: string(s)}
+	r.gatherer.Gather(status.Update{Key: string(statusKeyCurrentState), Value: string(s)})
 
 }
 

--- a/queues/loadrunner_test.go
+++ b/queues/loadrunner_test.go
@@ -8,7 +8,7 @@ import (
 
 type testLoadRunnerTestLoop struct{}
 
-func (d testLoadRunnerTestLoop) init(_ *testLoopExecution[loadElement], _ sleeper, _ *status.DefaultGatherer) {
+func (d testLoadRunnerTestLoop) init(_ *testLoopExecution[loadElement], _ sleeper, _ status.Gatherer) {
 	// No-op
 }
 

--- a/queues/loadrunner_test.go
+++ b/queues/loadrunner_test.go
@@ -8,7 +8,7 @@ import (
 
 type testLoadRunnerTestLoop struct{}
 
-func (d testLoadRunnerTestLoop) init(_ *testLoopExecution[loadElement], _ sleeper, _ *status.Gatherer) {
+func (d testLoadRunnerTestLoop) init(_ *testLoopExecution[loadElement], _ sleeper, _ *status.DefaultGatherer) {
 	// No-op
 }
 

--- a/queues/loadrunner_test.go
+++ b/queues/loadrunner_test.go
@@ -31,7 +31,7 @@ func TestRunLoadQueueTests(t *testing.T) {
 			r := loadRunner{assigner: assigner, stateList: []state{}, hzQueueStore: testHzQueueStore{}, l: testLoadRunnerTestLoop{}}
 
 			gatherer := status.NewGatherer()
-			go gatherer.Listen()
+			go gatherer.Listen(make(chan struct{}, 1))
 
 			r.runQueueTests(hzCluster, hzMembers, gatherer, initTestQueueStore)
 			gatherer.StopListen()
@@ -69,7 +69,7 @@ func TestRunLoadQueueTests(t *testing.T) {
 			r := loadRunner{assigner: assigner, stateList: []state{}, hzQueueStore: testHzQueueStore{}, l: testLoadRunnerTestLoop{}}
 
 			gatherer := status.NewGatherer()
-			go gatherer.Listen()
+			go gatherer.Listen(make(chan struct{}, 1))
 
 			r.runQueueTests(hzCluster, hzMembers, gatherer, initTestQueueStore)
 			gatherer.StopListen()
@@ -100,7 +100,7 @@ func TestRunLoadQueueTests(t *testing.T) {
 			ch := &testHzClientHandler{}
 			r := loadRunner{assigner: assigner, stateList: []state{}, hzQueueStore: testHzQueueStore{}, l: testLoadRunnerTestLoop{}, hzClientHandler: ch}
 			gatherer := status.NewGatherer()
-			go gatherer.Listen()
+			go gatherer.Listen(make(chan struct{}, 1))
 
 			qs := &testHzQueueStore{observations: &testQueueStoreObservations{}}
 			r.runQueueTests(hzCluster, hzMembers, gatherer, func(_ hazelcastwrapper.HzClientHandler) hazelcastwrapper.QueueStore {

--- a/queues/runner.go
+++ b/queues/runner.go
@@ -266,7 +266,11 @@ func (t *QueueTester) TestQueues() {
 			defer wg.Done()
 
 			gatherer := status.NewGatherer()
-			go gatherer.Listen()
+			listenReady := make(chan struct{})
+
+			go gatherer.Listen(listenReady)
+			<-listenReady
+
 			defer gatherer.StopListen()
 
 			runner := runners[i]

--- a/queues/runner.go
+++ b/queues/runner.go
@@ -18,7 +18,7 @@ type (
 	}
 	runner interface {
 		getSourceName() string
-		runQueueTests(hzCluster string, hzMembers []string, gatherer *status.DefaultGatherer, storeFunc initQueueStoreFunc)
+		runQueueTests(hzCluster string, hzMembers []string, gatherer status.Gatherer, storeFunc initQueueStoreFunc)
 	}
 	runnerConfig struct {
 		enabled                     bool

--- a/queues/runner.go
+++ b/queues/runner.go
@@ -18,7 +18,7 @@ type (
 	}
 	runner interface {
 		getSourceName() string
-		runQueueTests(hzCluster string, hzMembers []string, gatherer *status.Gatherer, storeFunc initQueueStoreFunc)
+		runQueueTests(hzCluster string, hzMembers []string, gatherer *status.DefaultGatherer, storeFunc initQueueStoreFunc)
 	}
 	runnerConfig struct {
 		enabled                     bool

--- a/queues/runner_test.go
+++ b/queues/runner_test.go
@@ -47,7 +47,7 @@ var (
 	}
 )
 
-func waitForStatusGatheringDone(g *status.DefaultGatherer) {
+func waitForStatusGatheringDone(g status.Gatherer) {
 
 	for {
 		if done := g.ListeningStopped(); done {
@@ -57,7 +57,7 @@ func waitForStatusGatheringDone(g *status.DefaultGatherer) {
 
 }
 
-func latestStatePresentInGatherer(g *status.DefaultGatherer, desiredState state) bool {
+func latestStatePresentInGatherer(g status.Gatherer, desiredState state) bool {
 
 	if value, ok := g.AssembleStatusCopy()[string(statusKeyCurrentState)]; ok && value == string(desiredState) {
 		return true

--- a/queues/runner_test.go
+++ b/queues/runner_test.go
@@ -47,7 +47,7 @@ var (
 	}
 )
 
-func waitForStatusGatheringDone(g *status.Gatherer) {
+func waitForStatusGatheringDone(g *status.DefaultGatherer) {
 
 	for {
 		if done := g.ListeningStopped(); done {
@@ -57,7 +57,7 @@ func waitForStatusGatheringDone(g *status.Gatherer) {
 
 }
 
-func latestStatePresentInGatherer(g *status.Gatherer, desiredState state) bool {
+func latestStatePresentInGatherer(g *status.DefaultGatherer, desiredState state) bool {
 
 	if value, ok := g.AssembleStatusCopy()[string(statusKeyCurrentState)]; ok && value == string(desiredState) {
 		return true

--- a/queues/testloop.go
+++ b/queues/testloop.go
@@ -16,20 +16,20 @@ import (
 type (
 	evaluateTimeToSleep func(sc *sleepConfig) int
 	looper[t any]       interface {
-		init(lc *testLoopExecution[t], s sleeper, g *status.Gatherer)
+		init(lc *testLoopExecution[t], s sleeper, g *status.DefaultGatherer)
 		run()
 	}
 	sleeper interface {
 		sleep(sc *sleepConfig, sf evaluateTimeToSleep, kind, queueName, runnerName string, o operation)
 	}
 	counterTracker interface {
-		init(gatherer *status.Gatherer)
+		init(gatherer *status.DefaultGatherer)
 		increaseCounter(sk statusKey)
 	}
 	testLoop[t any] struct {
 		tle      *testLoopExecution[t]
 		s        sleeper
-		gatherer *status.Gatherer
+		gatherer *status.DefaultGatherer
 		ct       counterTracker
 	}
 	testLoopExecution[t any] struct {
@@ -46,7 +46,7 @@ type (
 	queueTestLoopCountersTracker struct {
 		counters map[statusKey]int
 		l        sync.Mutex
-		gatherer *status.Gatherer
+		gatherer *status.DefaultGatherer
 	}
 )
 
@@ -84,7 +84,7 @@ var (
 	counters = []statusKey{statusKeyNumFailedPuts, statusKeyNumFailedPolls, statusKeyNumNilPolls, statusKeyNumFailedCapacityChecks, statusKeyNumQueueFullEvents}
 )
 
-func (ct *queueTestLoopCountersTracker) init(gatherer *status.Gatherer) {
+func (ct *queueTestLoopCountersTracker) init(gatherer *status.DefaultGatherer) {
 	ct.gatherer = gatherer
 
 	ct.counters = make(map[statusKey]int)
@@ -111,7 +111,7 @@ func (ct *queueTestLoopCountersTracker) increaseCounter(sk statusKey) {
 
 }
 
-func (l *testLoop[t]) init(tle *testLoopExecution[t], s sleeper, g *status.Gatherer) {
+func (l *testLoop[t]) init(tle *testLoopExecution[t], s sleeper, g *status.DefaultGatherer) {
 	l.tle = tle
 	l.s = s
 	l.gatherer = g

--- a/queues/testloop_test.go
+++ b/queues/testloop_test.go
@@ -101,7 +101,8 @@ func TestQueueTestLoopCountersTrackerIncreaseCounter(t *testing.T) {
 					}
 
 					msg = "\t\t\tcorresponding update must have been sent to status gatherer"
-					update := <-ct.gatherer.Updates
+					g := ct.gatherer.(*status.DefaultGatherer)
+					update := <-g.Updates
 					if update.Key == string(v) && update.Value == 1 {
 						t.Log(msg, checkMark, v)
 					} else {
@@ -710,7 +711,7 @@ func operationConfigStatusContainsExpectedValues(status map[string]any, expected
 
 }
 
-func assembleTestLoop(id uuid.UUID, source string, qs hazelcastwrapper.QueueStore, rc *runnerConfig, g *status.DefaultGatherer) testLoop[string] {
+func assembleTestLoop(id uuid.UUID, source string, qs hazelcastwrapper.QueueStore, rc *runnerConfig, g status.Gatherer) testLoop[string] {
 
 	tlc := assembleTestLoopConfig(id, source, qs, rc)
 	tl := testLoop[string]{}

--- a/queues/testloop_test.go
+++ b/queues/testloop_test.go
@@ -39,7 +39,7 @@ func TestQueueTestLoopCountersTrackerInit(t *testing.T) {
 			ct := &queueTestLoopCountersTracker{}
 			g := status.NewGatherer()
 
-			go g.Listen()
+			go g.Listen(make(chan struct{}, 1))
 			ct.init(g)
 			g.StopListen()
 
@@ -118,7 +118,7 @@ func TestQueueTestLoopCountersTrackerIncreaseCounter(t *testing.T) {
 				l:        sync.Mutex{},
 				gatherer: status.NewGatherer(),
 			}
-			go ct.gatherer.Listen()
+			go ct.gatherer.Listen(make(chan struct{}, 1))
 			ct.counters[statusKeyNumFailedPuts] = 0
 			numInvokingGoroutines := 100
 			for i := 0; i < numInvokingGoroutines; i++ {
@@ -157,7 +157,7 @@ func TestPutElements(t *testing.T) {
 			gatherer := status.NewGatherer()
 			tl := assembleTestLoop(uuid.New(), testSource, qs, &rc, gatherer)
 
-			go gatherer.Listen()
+			go gatherer.Listen(make(chan struct{}, 1))
 			tl.putElements(qs.q, "awesomeQueue")
 			gatherer.StopListen()
 
@@ -194,7 +194,7 @@ func TestPutElements(t *testing.T) {
 			gatherer := status.NewGatherer()
 			tl := assembleTestLoop(uuid.New(), testSource, qs, &rc, gatherer)
 
-			go gatherer.Listen()
+			go gatherer.Listen(make(chan struct{}, 1))
 			tl.putElements(qs.q, "awesomeQueue")
 			gatherer.StopListen()
 
@@ -232,7 +232,7 @@ func TestPutElements(t *testing.T) {
 			gatherer := status.NewGatherer()
 			tl := assembleTestLoop(uuid.New(), testSource, qs, &rc, gatherer)
 
-			go gatherer.Listen()
+			go gatherer.Listen(make(chan struct{}, 1))
 			tl.putElements(qs.q, "anotherAwesomeQueue")
 			gatherer.StopListen()
 
@@ -262,7 +262,7 @@ func TestPutElements(t *testing.T) {
 			rc := assembleRunnerConfig(true, 1, false, 1, sleepConfigDisabled, sleepConfigDisabled)
 			tl := assembleTestLoop(uuid.New(), testSource, qs, &rc, status.NewGatherer())
 
-			go tl.gatherer.Listen()
+			go tl.gatherer.Listen(make(chan struct{}, 1))
 			tl.putElements(qs.q, "yetAnotherAwesomeQueue")
 			tl.gatherer.StopListen()
 
@@ -300,7 +300,7 @@ func TestPollElements(t *testing.T) {
 			gatherer := status.NewGatherer()
 			tl := assembleTestLoop(uuid.New(), testSource, qs, &rc, gatherer)
 
-			go gatherer.Listen()
+			go gatherer.Listen(make(chan struct{}, 1))
 			tl.pollElements(qs.q, "yeehawQueue")
 			gatherer.StopListen()
 
@@ -332,7 +332,7 @@ func TestPollElements(t *testing.T) {
 			gatherer := status.NewGatherer()
 			tl := assembleTestLoop(uuid.New(), testSource, qs, &rc, gatherer)
 
-			go gatherer.Listen()
+			go gatherer.Listen(make(chan struct{}, 1))
 			tl.pollElements(qs.q, "anotherYeehawQueue")
 			gatherer.StopListen()
 
@@ -366,7 +366,7 @@ func TestPollElements(t *testing.T) {
 			gatherer := status.NewGatherer()
 			tl := assembleTestLoop(uuid.New(), testSource, qs, &rc, gatherer)
 
-			go gatherer.Listen()
+			go gatherer.Listen(make(chan struct{}, 1))
 			tl.pollElements(qs.q, "yetAnotherYeehawQueue")
 			gatherer.StopListen()
 
@@ -403,7 +403,7 @@ func TestRun(t *testing.T) {
 			gatherer := status.NewGatherer()
 			tl := assembleTestLoop(uuid.New(), testSource, qs, &rc, gatherer)
 
-			go gatherer.Listen()
+			go gatherer.Listen(make(chan struct{}, 1))
 			tl.run()
 			gatherer.StopListen()
 
@@ -448,7 +448,7 @@ func TestRun(t *testing.T) {
 		gatherer := status.NewGatherer()
 		tl := assembleTestLoop(uuid.New(), testSource, qs, &rc, gatherer)
 
-		go gatherer.Listen()
+		go gatherer.Listen(make(chan struct{}, 1))
 		tl.run()
 		gatherer.StopListen()
 
@@ -484,7 +484,7 @@ func TestRun(t *testing.T) {
 		gatherer := status.NewGatherer()
 		tl := assembleTestLoop(uuid.New(), testSource, qs, &rc, gatherer)
 
-		go gatherer.Listen()
+		go gatherer.Listen(make(chan struct{}, 1))
 		tl.run()
 		gatherer.StopListen()
 
@@ -514,7 +514,7 @@ func TestRun(t *testing.T) {
 		gatherer := status.NewGatherer()
 		tl := assembleTestLoop(uuid.New(), testSource, qs, &rc, gatherer)
 
-		go gatherer.Listen()
+		go gatherer.Listen(make(chan struct{}, 1))
 		tl.run()
 		gatherer.StopListen()
 
@@ -555,7 +555,7 @@ func TestRun(t *testing.T) {
 			return 0
 		}
 
-		go gatherer.Listen()
+		go gatherer.Listen(make(chan struct{}, 1))
 		tl.run()
 		gatherer.StopListen()
 
@@ -596,7 +596,7 @@ func TestRun(t *testing.T) {
 			return 0
 		}
 
-		go gatherer.Listen()
+		go gatherer.Listen(make(chan struct{}, 1))
 		tl.run()
 		gatherer.StopListen()
 
@@ -636,7 +636,7 @@ func TestRun(t *testing.T) {
 			return 0
 		}
 
-		go gatherer.Listen()
+		go gatherer.Listen(make(chan struct{}, 1))
 		tl.run()
 		gatherer.StopListen()
 

--- a/queues/testloop_test.go
+++ b/queues/testloop_test.go
@@ -710,7 +710,7 @@ func operationConfigStatusContainsExpectedValues(status map[string]any, expected
 
 }
 
-func assembleTestLoop(id uuid.UUID, source string, qs hazelcastwrapper.QueueStore, rc *runnerConfig, g *status.Gatherer) testLoop[string] {
+func assembleTestLoop(id uuid.UUID, source string, qs hazelcastwrapper.QueueStore, rc *runnerConfig, g *status.DefaultGatherer) testLoop[string] {
 
 	tlc := assembleTestLoopConfig(id, source, qs, rc)
 	tl := testLoop[string]{}

--- a/queues/tweetrunner.go
+++ b/queues/tweetrunner.go
@@ -24,7 +24,7 @@ type (
 		hzClientHandler hazelcastwrapper.HzClientHandler
 		hzQueueStore    hazelcastwrapper.QueueStore
 		l               looper[tweet]
-		gatherer        *status.DefaultGatherer
+		gatherer        status.Gatherer
 	}
 	tweetCollection struct {
 		Tweets []tweet `json:"Tweets"`
@@ -57,7 +57,7 @@ func (r *tweetRunner) getSourceName() string {
 	return "tweetRunner"
 }
 
-func (r *tweetRunner) runQueueTests(hzCluster string, hzMembers []string, gatherer *status.DefaultGatherer, storeFunc initQueueStoreFunc) {
+func (r *tweetRunner) runQueueTests(hzCluster string, hzMembers []string, gatherer status.Gatherer, storeFunc initQueueStoreFunc) {
 
 	r.gatherer = gatherer
 	r.appendState(start)
@@ -110,7 +110,7 @@ func (r *tweetRunner) runQueueTests(hzCluster string, hzMembers []string, gather
 func (r *tweetRunner) appendState(s state) {
 	r.stateList = append(r.stateList, s)
 
-	r.gatherer.Updates <- status.Update{Key: string(statusKeyCurrentState), Value: string(s)}
+	r.gatherer.Gather(status.Update{Key: string(statusKeyCurrentState), Value: string(s)})
 }
 
 func parseTweets() (*tweetCollection, error) {

--- a/queues/tweetrunner.go
+++ b/queues/tweetrunner.go
@@ -24,7 +24,7 @@ type (
 		hzClientHandler hazelcastwrapper.HzClientHandler
 		hzQueueStore    hazelcastwrapper.QueueStore
 		l               looper[tweet]
-		gatherer        *status.Gatherer
+		gatherer        *status.DefaultGatherer
 	}
 	tweetCollection struct {
 		Tweets []tweet `json:"Tweets"`
@@ -57,7 +57,7 @@ func (r *tweetRunner) getSourceName() string {
 	return "tweetRunner"
 }
 
-func (r *tweetRunner) runQueueTests(hzCluster string, hzMembers []string, gatherer *status.Gatherer, storeFunc initQueueStoreFunc) {
+func (r *tweetRunner) runQueueTests(hzCluster string, hzMembers []string, gatherer *status.DefaultGatherer, storeFunc initQueueStoreFunc) {
 
 	r.gatherer = gatherer
 	r.appendState(start)

--- a/queues/tweetrunner_test.go
+++ b/queues/tweetrunner_test.go
@@ -8,7 +8,7 @@ import (
 
 type testTweetRunnerTestLoop struct{}
 
-func (d testTweetRunnerTestLoop) init(_ *testLoopExecution[tweet], _ sleeper, _ *status.DefaultGatherer) {
+func (d testTweetRunnerTestLoop) init(_ *testLoopExecution[tweet], _ sleeper, _ status.Gatherer) {
 	// No-op
 }
 

--- a/queues/tweetrunner_test.go
+++ b/queues/tweetrunner_test.go
@@ -8,7 +8,7 @@ import (
 
 type testTweetRunnerTestLoop struct{}
 
-func (d testTweetRunnerTestLoop) init(_ *testLoopExecution[tweet], _ sleeper, _ *status.Gatherer) {
+func (d testTweetRunnerTestLoop) init(_ *testLoopExecution[tweet], _ sleeper, _ *status.DefaultGatherer) {
 	// No-op
 }
 

--- a/queues/tweetrunner_test.go
+++ b/queues/tweetrunner_test.go
@@ -30,7 +30,7 @@ func TestRunTweetQueueTests(t *testing.T) {
 			}
 			r := tweetRunner{assigner: assigner, stateList: []state{}, hzQueueStore: testHzQueueStore{}, l: testTweetRunnerTestLoop{}}
 			gatherer := status.NewGatherer()
-			go gatherer.Listen()
+			go gatherer.Listen(make(chan struct{}, 1))
 
 			r.runQueueTests(hzCluster, hzMembers, gatherer, initTestQueueStore)
 			gatherer.StopListen()
@@ -66,7 +66,7 @@ func TestRunTweetQueueTests(t *testing.T) {
 			}
 			r := tweetRunner{assigner: assigner, stateList: []state{}, hzQueueStore: testHzQueueStore{}, l: testTweetRunnerTestLoop{}}
 			gatherer := status.NewGatherer()
-			go gatherer.Listen()
+			go gatherer.Listen(make(chan struct{}, 1))
 
 			r.runQueueTests(hzCluster, hzMembers, gatherer, initTestQueueStore)
 			gatherer.StopListen()
@@ -99,7 +99,7 @@ func TestRunTweetQueueTests(t *testing.T) {
 			r := tweetRunner{assigner: assigner, stateList: []state{}, hzQueueStore: testHzQueueStore{}, l: testTweetRunnerTestLoop{}, hzClientHandler: ch}
 
 			gatherer := status.NewGatherer()
-			go gatherer.Listen()
+			go gatherer.Listen(make(chan struct{}, 1))
 
 			qs := &testHzQueueStore{observations: &testQueueStoreObservations{}}
 			r.runQueueTests(hzCluster, hzMembers, gatherer, func(_ hazelcastwrapper.HzClientHandler) hazelcastwrapper.QueueStore {

--- a/resources/charts/hazeltest/Chart.yaml
+++ b/resources/charts/hazeltest/Chart.yaml
@@ -4,6 +4,6 @@ description: A Helm chart for deploying Hazeltest on Kubernetes
 
 type: application
 
-version: 1.2.1-0.15.0
+version: 1.2.1-0.15.1
 
-appVersion: "0.15.0"
+appVersion: "0.15.1"

--- a/resources/charts/hazeltest/values.yaml
+++ b/resources/charts/hazeltest/values.yaml
@@ -77,6 +77,7 @@ config:
       prefix:
         enabled: true
         prefix: "ht_"
+      parallelCleanNumDataStructuresDivisor: 10
       cleanAgainThreshold:
         enabled: true
         thresholdMs: 30000
@@ -86,6 +87,7 @@ config:
       prefix:
         enabled: true
         prefix: "ht_"
+      parallelCleanNumDataStructuresDivisor: 10
       cleanAgainThreshold:
         enabled: true
         thresholdMs: 30000

--- a/resources/charts/hazeltest/values.yaml
+++ b/resources/charts/hazeltest/values.yaml
@@ -4,8 +4,8 @@ image:
   registry: docker.io
   organization: antsinmyey3sjohnson
   repository: hazeltest
-  tag: 0.15.0
-  digest: 9ed30d24519254d9da5575b029c538bc1207424f83a0c506cf212e109bfd4e2d
+  tag: 0.15.1
+  digest: c702f1f77d2a18915f3c87366e685bfa0342d73c3c606c6ba16644ccb4b15fd4
   pullPolicy: IfNotPresent
 
 resources:

--- a/resources/charts/hazeltest/values.yaml
+++ b/resources/charts/hazeltest/values.yaml
@@ -5,7 +5,7 @@ image:
   organization: antsinmyey3sjohnson
   repository: hazeltest
   tag: 0.15.1
-  digest: c702f1f77d2a18915f3c87366e685bfa0342d73c3c606c6ba16644ccb4b15fd4
+  digest: ad97bd08556036fbe2fec7ce9da6e4b945cce24b8e520be798f5871f0b168240
   pullPolicy: IfNotPresent
 
 resources:

--- a/state/cleaner.go
+++ b/state/cleaner.go
@@ -667,7 +667,7 @@ func performParallelSingleCleans(
 		return results
 	}
 
-	lp.LogStateCleanerEvent(fmt.Sprintf("using %d worker/-s to perform parallel single clean on %d data structure/-s", numWorkers, len(filteredDataStructures)), hzService, log.TraceLevel)
+	lp.LogStateCleanerEvent(fmt.Sprintf("using %d worker/-s to perform parallel single clean on %d data structure/-s", numWorkers, len(filteredDataStructures)), hzService, log.InfoLevel)
 	cleanTasks := make(chan string, len(filteredDataStructures))
 	errorDuringProcessing := make(chan struct{})
 

--- a/state/cleaner.go
+++ b/state/cleaner.go
@@ -605,8 +605,8 @@ func runGenericBatchClean(
 			numCleanedDataStructures++
 			if err != nil {
 				if Ignore == cfg.errorBehavior {
-					lp.LogStateCleanerEvent(fmt.Sprintf("%d elements have been claned from paylod data structure "+
-						"'%s' and an error occured, but error behavior was configured as '%s' -- commencing batch clean after error: %v", numItemsCleaned, v.GetName(), Ignore, err), hzService, log.WarnLevel)
+					lp.LogStateCleanerEvent(fmt.Sprintf("%d elements have been cleaned from payload data structure "+
+						"'%s' and an error occured, but error behavior was configured to be '%s' -- commencing batch clean after error: %v", numItemsCleaned, v.GetName(), Ignore, err), hzService, log.WarnLevel)
 				} else {
 					lp.LogStateCleanerEvent(fmt.Sprintf("%d elements have been cleaned from payload data structure '%s', but an error occurred during cleaning: %v", numItemsCleaned, v.GetName(), err), hzService, log.ErrorLevel)
 					return numCleanedDataStructures, err

--- a/state/cleaner.go
+++ b/state/cleaner.go
@@ -306,7 +306,7 @@ func (cih *DefaultLastCleanedInfoHandler) check(syncMapName, payloadDataStructur
 		return emptyMapLockInfo, false, err
 	}
 
-	lp.LogStateCleanerEvent(fmt.Sprintf("successfully retrieved sync map '%s'", syncMapName), hzService, log.DebugLevel)
+	lp.LogStateCleanerEvent(fmt.Sprintf("successfully retrieved sync map '%s'", syncMapName), hzService, log.TraceLevel)
 	lockSucceeded, err := syncMap.TryLock(cih.Ctx, payloadDataStructureName)
 
 	if err != nil {
@@ -324,7 +324,7 @@ func (cih *DefaultLastCleanedInfoHandler) check(syncMapName, payloadDataStructur
 		key:     payloadDataStructureName,
 	}
 
-	lp.LogStateCleanerEvent(fmt.Sprintf("successfully acquired lock on sync map '%s' for payload data structure '%s'", syncMapName, payloadDataStructureName), hzService, log.DebugLevel)
+	lp.LogStateCleanerEvent(fmt.Sprintf("successfully acquired lock on sync map '%s' for payload data structure '%s'", syncMapName, payloadDataStructureName), hzService, log.TraceLevel)
 	if !cih.Cfg.UseCleanAgainThreshold {
 		// No need to check for the last cleaned timestamp if the cleaner was advised not to apply a clean again threshold
 		// (Caution: One might be tempted to check whether to apply a threshold right at the beginning of this method,
@@ -346,7 +346,7 @@ func (cih *DefaultLastCleanedInfoHandler) check(syncMapName, payloadDataStructur
 
 	// Value will be nil if key (name of payload map) was not present in sync map
 	if v == nil {
-		lp.LogStateCleanerEvent(fmt.Sprintf("determined that payload data structure '%s' was never cleaned before", payloadDataStructureName), hzService, log.DebugLevel)
+		lp.LogStateCleanerEvent(fmt.Sprintf("determined that payload data structure '%s' was never cleaned before", payloadDataStructureName), hzService, log.TraceLevel)
 		return lockInfo, true, nil
 	}
 
@@ -360,13 +360,13 @@ func (cih *DefaultLastCleanedInfoHandler) check(syncMapName, payloadDataStructur
 	}
 
 	cleanAgainThresholdMs := cih.Cfg.CleanAgainThresholdMs
-	lp.LogStateCleanerEvent(fmt.Sprintf("successfully retrieved last updated info from sync map '%s' for payload data structure '%s'; last updated at %d", syncMapName, payloadDataStructureName, lastCleanedAt), hzService, log.DebugLevel)
+	lp.LogStateCleanerEvent(fmt.Sprintf("successfully retrieved last updated info from sync map '%s' for payload data structure '%s'; last updated at %d", syncMapName, payloadDataStructureName, lastCleanedAt), hzService, log.TraceLevel)
 	if time.Since(time.Unix(lastCleanedAt, 0)) < time.Millisecond*time.Duration(cleanAgainThresholdMs) {
-		lp.LogStateCleanerEvent(fmt.Sprintf("determined that difference between last cleaned timestamp and current time is less than configured threshold of '%d' milliseconds for payload data structure '%s'-- negative cleaning suggestion", cleanAgainThresholdMs, payloadDataStructureName), hzService, log.DebugLevel)
+		lp.LogStateCleanerEvent(fmt.Sprintf("determined that difference between last cleaned timestamp and current time is less than configured threshold of '%d' milliseconds for payload data structure '%s'-- negative cleaning suggestion", cleanAgainThresholdMs, payloadDataStructureName), hzService, log.TraceLevel)
 		return lockInfo, false, nil
 	}
 
-	lp.LogStateCleanerEvent(fmt.Sprintf("determined that difference between last cleaned timestamp and current time is greater than or equal to configured threshold of '%d' milliseconds for payload data structure '%s'-- positive cleaning suggestion", cleanAgainThresholdMs, payloadDataStructureName), hzService, log.DebugLevel)
+	lp.LogStateCleanerEvent(fmt.Sprintf("determined that difference between last cleaned timestamp and current time is greater than or equal to configured threshold of '%d' milliseconds for payload data structure '%s'-- positive cleaning suggestion", cleanAgainThresholdMs, payloadDataStructureName), hzService, log.TraceLevel)
 	return lockInfo, true, nil
 
 }
@@ -464,7 +464,7 @@ func releaseLock(ctx context.Context, lockInfo mapLockInfo, hzService string) er
 		return err
 	}
 
-	lp.LogStateCleanerEvent(fmt.Sprintf("successfully released lock on sync map '%s' for key '%s'", lockInfo.mapName, lockInfo.key), hzService, log.InfoLevel)
+	lp.LogStateCleanerEvent(fmt.Sprintf("successfully released lock on sync map '%s' for key '%s'", lockInfo.mapName, lockInfo.key), hzService, log.TraceLevel)
 	return nil
 
 }
@@ -504,11 +504,11 @@ func runGenericSingleClean(
 	}
 
 	if !shouldClean {
-		lp.LogStateCleanerEvent(fmt.Sprintf("clean not required for '%s'", payloadDataStructureName), hzService, log.InfoLevel)
+		lp.LogStateCleanerEvent(fmt.Sprintf("clean not required for '%s'", payloadDataStructureName), hzService, log.TraceLevel)
 		return SingleCleanResult{0, nil}
 	}
 
-	lp.LogStateCleanerEvent(fmt.Sprintf("determined that '%s' should be cleaned of state, commencing...", payloadDataStructureName), hzService, log.InfoLevel)
+	lp.LogStateCleanerEvent(fmt.Sprintf("determined that '%s' should be cleaned of state, commencing...", payloadDataStructureName), hzService, log.TraceLevel)
 	numItemsCleaned, err := retrieveAndCleanFunc(payloadDataStructureName)
 
 	if err != nil {
@@ -518,7 +518,7 @@ func runGenericSingleClean(
 
 	if numItemsCleaned > 0 {
 		t.add(payloadDataStructureName, numItemsCleaned)
-		lp.LogStateCleanerEvent(fmt.Sprintf("successfully cleaned '%s', which held %d item/-s", payloadDataStructureName, numItemsCleaned), hzService, log.InfoLevel)
+		lp.LogStateCleanerEvent(fmt.Sprintf("successfully cleaned '%s', which held %d item/-s", payloadDataStructureName, numItemsCleaned), hzService, log.TraceLevel)
 	}
 
 	if err := cih.update(lockInfo); err != nil {
@@ -526,7 +526,7 @@ func runGenericSingleClean(
 		return SingleCleanResult{numItemsCleaned, err}
 	}
 
-	lp.LogStateCleanerEvent(fmt.Sprintf("last cleaned info successfully updated for '%s'", payloadDataStructureName), hzService, log.InfoLevel)
+	lp.LogStateCleanerEvent(fmt.Sprintf("last cleaned info successfully updated for '%s'", payloadDataStructureName), hzService, log.TraceLevel)
 	return SingleCleanResult{numItemsCleaned, err}
 
 }
@@ -554,11 +554,11 @@ func (c *DefaultSingleMapCleaner) retrieveAndClean(payloadMapName string) (int, 
 	}
 
 	if size == 0 {
-		lp.LogStateCleanerEvent(fmt.Sprintf("payload map '%s' does not currently hold any items -- skipping", payloadMapName), HzMapService, log.DebugLevel)
+		lp.LogStateCleanerEvent(fmt.Sprintf("payload map '%s' does not currently hold any items -- skipping", payloadMapName), HzMapService, log.TraceLevel)
 		return 0, nil
 	}
 
-	lp.LogStateCleanerEvent(fmt.Sprintf("payload map '%s' currently holds %d elements -- proceeding to clean", payloadMapName, size), HzMapService, log.DebugLevel)
+	lp.LogStateCleanerEvent(fmt.Sprintf("payload map '%s' currently holds %d elements -- proceeding to clean", payloadMapName, size), HzMapService, log.TraceLevel)
 
 	if err := mapToClean.EvictAll(c.ctx); err != nil {
 		lp.LogStateCleanerEvent(fmt.Sprintf("encountered error upon cleaning '%s': %v", payloadMapName, err), HzMapService, log.ErrorLevel)
@@ -676,10 +676,10 @@ func performParallelSingleCleans(
 							close(errorDuringProcessing)
 						})
 					} else {
-						lp.LogStateCleanerEvent(fmt.Sprintf("encountered error upon cleaning data structure with name '%s', but error behavior was set to '%s', hence commencing after error: %v", task, Ignore, result.Err), hzService, log.InfoLevel)
+						lp.LogStateCleanerEvent(fmt.Sprintf("encountered error upon cleaning data structure with name '%s', but error behavior was set to '%s', hence commencing after error: %v", task, Ignore, result.Err), hzService, log.TraceLevel)
 					}
 				} else {
-					lp.LogStateCleanerEvent(fmt.Sprintf("successfully cleaned %d element/-s from data structure with name '%s'", result.NumCleanedItems, task), hzService, log.InfoLevel)
+					lp.LogStateCleanerEvent(fmt.Sprintf("successfully cleaned %d element/-s from data structure with name '%s'", result.NumCleanedItems, task), hzService, log.TraceLevel)
 				}
 			}
 		}()
@@ -739,11 +739,11 @@ func (c *DefaultSingleQueueCleaner) retrieveAndClean(payloadQueueName string) (i
 	}
 
 	if size == 0 {
-		lp.LogStateCleanerEvent(fmt.Sprintf("payload queue '%s' does not currently hold any items -- skipping", payloadQueueName), HzQueueService, log.DebugLevel)
+		lp.LogStateCleanerEvent(fmt.Sprintf("payload queue '%s' does not currently hold any items -- skipping", payloadQueueName), HzQueueService, log.TraceLevel)
 		return 0, nil
 	}
 
-	lp.LogStateCleanerEvent(fmt.Sprintf("payload queue '%s' currently holds %d elements -- proceeding to clean", payloadQueueName, size), HzQueueService, log.DebugLevel)
+	lp.LogStateCleanerEvent(fmt.Sprintf("payload queue '%s' currently holds %d elements -- proceeding to clean", payloadQueueName, size), HzQueueService, log.TraceLevel)
 
 	if err := queueToClean.Clear(c.ctx); err != nil {
 		lp.LogStateCleanerEvent(fmt.Sprintf("encountered error upon cleaning '%s': %v", payloadQueueName, err), HzQueueService, log.ErrorLevel)

--- a/state/cleaner.go
+++ b/state/cleaner.go
@@ -395,13 +395,18 @@ func (c *DefaultBatchMapCleaner) Clean() (int, error) {
 	b := DefaultSingleMapCleanerBuilder{}
 	sc, _ := b.Build(c.ctx, c.ms, c.t, c.cih)
 
-	return runGenericBatchClean(
+	start := time.Now()
+	numCleanedMaps, err := runGenericBatchClean(
 		c.ctx,
 		c.ois,
 		HzMapService,
 		c.cfg,
 		sc,
 	)
+	elapsed := time.Since(start).Milliseconds()
+	lp.LogTimingEvent("batch map clean", "N/A", int(elapsed), log.InfoLevel)
+
+	return numCleanedMaps, err
 
 }
 
@@ -774,6 +779,8 @@ func (c *DefaultBatchQueueCleaner) Clean() (int, error) {
 
 	b := DefaultSingleQueueCleanerBuilder{}
 	sc, _ := b.Build(c.ctx, c.qs, c.ms, c.t, c.cih)
+
+	start := time.Now()
 	numCleaned, err := runGenericBatchClean(
 		c.ctx,
 		c.ois,
@@ -781,6 +788,8 @@ func (c *DefaultBatchQueueCleaner) Clean() (int, error) {
 		c.cfg,
 		sc,
 	)
+	elapsed := time.Since(start).Milliseconds()
+	lp.LogTimingEvent("batch queue clean", "N/A", int(elapsed), log.InfoLevel)
 
 	return numCleaned, err
 

--- a/state/cleaner.go
+++ b/state/cleaner.go
@@ -610,37 +610,13 @@ func runGenericBatchClean(
 	}
 
 	numCleanedDataStructures := 0
-	for _, v := range filteredDataStructures {
-		cleanResults := performParallelSingleCleans(filteredDataStructures, cfg.errorBehavior, sc.Clean)
-		for result := range cleanResults {
-			numItemsCleaned, err := result.numCleanedItems, result.err
-			if numItemsCleaned > 0 {
-				numCleanedDataStructures++
-				if err != nil {
-					if Ignore == cfg.errorBehavior {
-						lp.LogStateCleanerEvent(fmt.Sprintf("%d elements have been cleaned from payload data structure "+
-							"'%s' and an error occured, but error behavior was configured to be '%s' -- commencing batch clean after error: %v", numItemsCleaned, v.GetName(), Ignore, err), hzService, log.WarnLevel)
-					} else {
-						lp.LogStateCleanerEvent(fmt.Sprintf("%d elements have been cleaned from payload data structure '%s', but an error occurred during cleaning: %v", numItemsCleaned, v.GetName(), err), hzService, log.ErrorLevel)
-						return numCleanedDataStructures, err
-					}
-				} else {
-					lp.LogStateCleanerEvent(fmt.Sprintf("successfully cleaned %d elements from payload data structure '%s'; cleaned %d data structure/-s so far", numItemsCleaned, v.GetName(), numCleanedDataStructures), hzService, log.InfoLevel)
-				}
-			} else {
-				if err != nil {
-					if Ignore == cfg.errorBehavior {
-						lp.LogStateCleanerEvent(fmt.Sprintf("error occured upon attempt to clean payload data structure '%s', but error behavior was configured to be '%s', so error will be ignored: %v", v.GetName(), Ignore, err), hzService, log.WarnLevel)
-					} else {
-						lp.LogStateCleanerEvent(fmt.Sprintf("unable to clean '%s' due to error: %v", v.GetName(), err), hzService, log.ErrorLevel)
-						return numCleanedDataStructures, err
-					}
-				} else {
-					lp.LogStateCleanerEvent(fmt.Sprintf("invocation of clean was successful on payload data structure '%s'; however, zero items were cleaned", v.GetName()), hzService, log.InfoLevel)
-				}
-			}
-		}
 
+	cleanResults := performParallelSingleCleans(filteredDataStructures, cfg.errorBehavior, sc.Clean, hzService)
+	for result := range cleanResults {
+		numItemsCleaned := result.numCleanedItems
+		if numItemsCleaned > 0 {
+			numCleanedDataStructures++
+		}
 	}
 
 	return numCleanedDataStructures, nil

--- a/state/cleaner_test.go
+++ b/state/cleaner_test.go
@@ -4933,7 +4933,7 @@ func assembleTestConfig(basePath string) map[string]any {
 
 }
 
-func waitForStatusGatheringDone(g *status.DefaultGatherer) {
+func waitForStatusGatheringDone(g status.Gatherer) {
 
 	for {
 		if done := g.ListeningStopped(); done {

--- a/state/cleaner_test.go
+++ b/state/cleaner_test.go
@@ -488,21 +488,37 @@ func TestCalculateNumParallelSingleCleanWorkers(t *testing.T) {
 	{
 		t.Log("\twhen number of data structures is zero")
 		{
-			msg := "\t\tcalculated number of workers must be zero"
+			nw, err := calculateNumParallelSingleCleanWorkers(0, uint16(10))
 
-			if calculateNumParallelSingleCleanWorkers(0, uint16(10)) == 0 {
+			msg := "\t\terror must be returned"
+			if err != nil {
 				t.Log(msg, checkMark)
 			} else {
 				t.Fatal(msg, ballotX)
 			}
+
+			msg = "\t\treturned number of workers must be zero"
+			if nw == 0 {
+				t.Log(msg, checkMark)
+			} else {
+				t.Fatal(msg, ballotX)
+			}
+
 		}
 
 		t.Log("\twhen divisor is zero")
 		{
-			msg := "\t\tcalculated number of workers must be zero"
+			nw, err := calculateNumParallelSingleCleanWorkers(10, uint16(0))
 
-			numDataStructures := 10
-			if calculateNumParallelSingleCleanWorkers(numDataStructures, 0) == uint16(0) {
+			msg := "\t\terror must be returned"
+			if err != nil {
+				t.Log(msg, checkMark)
+			} else {
+				t.Fatal(msg, ballotX)
+			}
+
+			msg = "\t\treturned number of workers must be zero"
+			if nw == 0 {
 				t.Log(msg, checkMark)
 			} else {
 				t.Fatal(msg, ballotX)
@@ -511,9 +527,17 @@ func TestCalculateNumParallelSingleCleanWorkers(t *testing.T) {
 
 		t.Log("\twhen divisor is greater than number of filtered data structures")
 		{
-			msg := "\t\tcalculated number of workers must be one"
+			nw, err := calculateNumParallelSingleCleanWorkers(1, 20)
 
-			if calculateNumParallelSingleCleanWorkers(1, 20) == uint16(1) {
+			msg := "\t\tno error must be returned"
+			if err == nil {
+				t.Log(msg, checkMark)
+			} else {
+				t.Fatal(msg, ballotX)
+			}
+
+			msg = "\t\tcalculated number of workers must be one"
+			if nw == uint16(1) {
 				t.Log(msg, checkMark)
 			} else {
 				t.Fatal(msg, ballotX)
@@ -522,17 +546,24 @@ func TestCalculateNumParallelSingleCleanWorkers(t *testing.T) {
 
 		t.Log("\twhen greater-than-zero number of data structures is greater than or equal to divisor")
 		{
-			msg := "\t\tcalculated number of workers must be result of dividing number of datastructures by divisor"
+			msgNoError := "\t\tno error must be returned"
+			msgNumWorkers := "\t\tcalculated number of workers must be result of dividing number of datastructures by divisor"
 
 			for i := 1; i < 100; i += 5 {
 				numWorkers := i * 10
 				divisor := i
-				calculated := calculateNumParallelSingleCleanWorkers(numWorkers, uint16(divisor))
+				nw, err := calculateNumParallelSingleCleanWorkers(numWorkers, uint16(divisor))
 
-				if int(calculated) == numWorkers/divisor {
-					t.Log(msg, checkMark, numWorkers, divisor)
+				if err == nil {
+					t.Log(msgNoError, checkMark, numWorkers, divisor)
 				} else {
-					t.Fatal(msg, ballotX, numWorkers, divisor, calculated)
+					t.Fatal(msgNoError, ballotX, numWorkers, divisor, err)
+				}
+
+				if int(nw) == numWorkers/divisor {
+					t.Log(msgNumWorkers, checkMark, numWorkers, divisor)
+				} else {
+					t.Fatal(msgNumWorkers, ballotX, numWorkers, divisor, nw)
 				}
 			}
 

--- a/state/cleaner_test.go
+++ b/state/cleaner_test.go
@@ -572,7 +572,7 @@ func TestPerformParallelSingleCleans(t *testing.T) {
 				numCleanInvocations := 0
 				results := performParallelSingleCleans(ois.objectInfos, Ignore, func(name string) SingleCleanResult {
 					numCleanInvocations++
-					return SingleCleanResult{err: singleCleanerCleanError}
+					return SingleCleanResult{Err: singleCleanerCleanError}
 				}, HzMapService)
 
 				numResults := 0
@@ -603,7 +603,7 @@ func TestPerformParallelSingleCleans(t *testing.T) {
 				numCleanInvocations := 0
 				results := performParallelSingleCleans(ois.objectInfos, Fail, func(name string) SingleCleanResult {
 					numCleanInvocations++
-					return SingleCleanResult{err: singleCleanerCleanError}
+					return SingleCleanResult{Err: singleCleanerCleanError}
 				}, HzMapService)
 
 				numResults := 0
@@ -1670,17 +1670,17 @@ func TestDefaultSingleQueueCleaner_Clean(t *testing.T) {
 				scResult := qc.Clean("something")
 
 				msg := "\t\t\terror must be returned"
-				if scResult.err != nil {
+				if scResult.Err != nil {
 					t.Log(msg, checkMark)
 				} else {
 					t.Fatal(msg, ballotX)
 				}
 
 				msg = "\t\t\treported number of cleaned items must be zero"
-				if scResult.numCleanedItems == 0 {
+				if scResult.NumCleanedItems == 0 {
 					t.Log(msg, checkMark)
 				} else {
-					t.Fatal(msg, ballotX, scResult.numCleanedItems)
+					t.Fatal(msg, ballotX, scResult.NumCleanedItems)
 				}
 			}
 
@@ -1709,14 +1709,14 @@ func TestDefaultSingleQueueCleaner_Clean(t *testing.T) {
 				scResult := qc.Clean(prefix + baseName + "-0")
 
 				msg := "\t\t\tno error must be returned"
-				if scResult.err == nil {
+				if scResult.Err == nil {
 					t.Log(msg, checkMark)
 				} else {
 					t.Fatal(msg, ballotX)
 				}
 
 				msg = "\t\t\treported number of items cleaned from queue must be equal to number of items previously held by queue"
-				if scResult.numCleanedItems == numItemsInQueues {
+				if scResult.NumCleanedItems == numItemsInQueues {
 					t.Log(msg, checkMark)
 				} else {
 					t.Fatal(msg, ballotX)
@@ -2085,7 +2085,8 @@ func TestDefaultBatchQueueCleaner_Clean(t *testing.T) {
 		t.Log("\twhen retrieval of object info succeeds, but get queue operation fails")
 		{
 			c := &cleanerConfig{
-				enabled: true,
+				enabled:       true,
+				errorBehavior: Fail,
 			}
 			numPayloadQueueObjects := 9
 			prefixes := []string{"ht_"}
@@ -2160,7 +2161,8 @@ func TestDefaultBatchQueueCleaner_Clean(t *testing.T) {
 			qs.queues[erroneousClearQueueName].returnErrorUponClear = true
 
 			c := &cleanerConfig{
-				enabled: true,
+				enabled:       true,
+				errorBehavior: Fail,
 			}
 
 			tracker := &testCleanedTracker{}
@@ -2307,17 +2309,17 @@ func TestRunGenericSingleClean(t *testing.T) {
 			scResult := runGenericSingleClean(mc.ctx, mc.cih, mc.t, mapCleanersSyncMapName, payloadMapName, HzMapService, mc.retrieveAndClean)
 
 			msg := "\t\tcorrect error must be returned"
-			if errors.Is(scResult.err, lastCleanedInfoCheckError) {
+			if errors.Is(scResult.Err, lastCleanedInfoCheckError) {
 				t.Log(msg, checkMark)
 			} else {
-				t.Fatal(msg, ballotX, scResult.err)
+				t.Fatal(msg, ballotX, scResult.Err)
 			}
 
 			msg = "\t\treported number of cleaned items must be zero"
-			if scResult.numCleanedItems == 0 {
+			if scResult.NumCleanedItems == 0 {
 				t.Log(msg, checkMark)
 			} else {
-				t.Fatal(msg, ballotX, scResult.numCleanedItems)
+				t.Fatal(msg, ballotX, scResult.NumCleanedItems)
 			}
 
 			msg = "\t\tlast cleaned info check must have been invoked once"
@@ -2370,17 +2372,17 @@ func TestRunGenericSingleClean(t *testing.T) {
 			scResult := runGenericSingleClean(dmc.ctx, dmc.cih, tr, mapCleanersSyncMapName, payloadMapName, HzMapService, dmc.retrieveAndClean)
 
 			msg := "\t\tno error must be returned"
-			if scResult.err == nil {
+			if scResult.Err == nil {
 				t.Log(msg, checkMark)
 			} else {
-				t.Fatal(msg, ballotX, scResult.err)
+				t.Fatal(msg, ballotX, scResult.Err)
 			}
 
 			msg = "\t\treported number of cleaned items must be zero"
-			if scResult.numCleanedItems == 0 {
+			if scResult.NumCleanedItems == 0 {
 				t.Log(msg, checkMark)
 			} else {
-				t.Fatal(msg, ballotX, scResult.numCleanedItems)
+				t.Fatal(msg, ballotX, scResult.NumCleanedItems)
 			}
 
 			msg = "\t\ttry lock must have been invoked once on map cleaners sync map"
@@ -2432,17 +2434,17 @@ func TestRunGenericSingleClean(t *testing.T) {
 			scResult := runGenericSingleClean(mc.ctx, mc.cih, mc.t, mapCleanersSyncMapName, payloadMapName, HzMapService, mc.retrieveAndClean)
 
 			msg := "\t\terror must be returned"
-			if errors.Is(scResult.err, getPayloadMapError) {
+			if errors.Is(scResult.Err, getPayloadMapError) {
 				t.Log(msg, checkMark)
 			} else {
-				t.Fatal(msg, ballotX, scResult.err)
+				t.Fatal(msg, ballotX, scResult.Err)
 			}
 
 			msg = "\t\treported number of cleaned items must be zero"
-			if scResult.numCleanedItems == 0 {
+			if scResult.NumCleanedItems == 0 {
 				t.Log(msg, checkMark)
 			} else {
-				t.Fatal(msg, ballotX, scResult.numCleanedItems)
+				t.Fatal(msg, ballotX, scResult.NumCleanedItems)
 			}
 
 			msg = "\t\tunlock must have been invoked once on map cleaners sync map"
@@ -2497,17 +2499,17 @@ func TestRunGenericSingleClean(t *testing.T) {
 			scResult := mc.Clean(payloadMapName)
 
 			msg := "\t\terror must be returned"
-			if errors.Is(scResult.err, mapSizeError) {
+			if errors.Is(scResult.Err, mapSizeError) {
 				t.Log(msg, checkMark)
 			} else {
 				t.Fatal(msg, ballotX)
 			}
 
 			msg = "\t\treported number of items cleaned must be zero"
-			if scResult.numCleanedItems == 0 {
+			if scResult.NumCleanedItems == 0 {
 				t.Log(msg, checkMark)
 			} else {
-				t.Fatal(msg, ballotX, scResult.numCleanedItems)
+				t.Fatal(msg, ballotX, scResult.NumCleanedItems)
 			}
 
 			msg = "\t\tno last cleaned info update must have been performed"
@@ -2559,17 +2561,17 @@ func TestRunGenericSingleClean(t *testing.T) {
 			scResult := runGenericSingleClean(mc.ctx, mc.cih, mc.t, mapCleanersSyncMapName, payloadMapName, HzMapService, mc.retrieveAndClean)
 
 			msg := "\t\terror must be returned"
-			if errors.Is(scResult.err, mapEvictAllError) {
+			if errors.Is(scResult.Err, mapEvictAllError) {
 				t.Log(msg, checkMark)
 			} else {
-				t.Fatal(msg, ballotX, scResult.err)
+				t.Fatal(msg, ballotX, scResult.Err)
 			}
 
 			msg = "\t\treported number of cleaned items must be zero"
-			if scResult.numCleanedItems == 0 {
+			if scResult.NumCleanedItems == 0 {
 				t.Log(msg, checkMark)
 			} else {
-				t.Fatal(msg, ballotX, scResult.numCleanedItems)
+				t.Fatal(msg, ballotX, scResult.NumCleanedItems)
 			}
 
 			msg = "\t\tevict all must have been invoked once on payload map"
@@ -2625,17 +2627,17 @@ func TestRunGenericSingleClean(t *testing.T) {
 			scResult := mc.Clean(mapPrefix + "load-0")
 
 			msg := "\t\tno error must be returned"
-			if scResult.err == nil {
+			if scResult.Err == nil {
 				t.Log(msg, checkMark)
 			} else {
 				t.Fatal(msg, ballotX)
 			}
 
 			msg = "\t\treported number of cleaned items must be zero"
-			if scResult.numCleanedItems == 0 {
+			if scResult.NumCleanedItems == 0 {
 				t.Log(msg, checkMark)
 			} else {
-				t.Fatal(msg, ballotX, scResult.numCleanedItems)
+				t.Fatal(msg, ballotX, scResult.NumCleanedItems)
 			}
 
 			msg = "\t\tdata structure must not have been added to cleaned data structure tracker"
@@ -2686,17 +2688,17 @@ func TestRunGenericSingleClean(t *testing.T) {
 			scResult := runGenericSingleClean(mc.ctx, mc.cih, mc.t, mapCleanersSyncMapName, payloadMapName, HzMapService, mc.retrieveAndClean)
 
 			msg := "\t\terror must be returned"
-			if errors.Is(scResult.err, lastCleanedInfoUpdateError) {
+			if errors.Is(scResult.Err, lastCleanedInfoUpdateError) {
 				t.Log(msg, checkMark)
 			} else {
 				t.Fatal(msg, ballotX)
 			}
 
 			msg = "\t\treported number of cleaned items must be equal to number of items previously held by payload map"
-			if scResult.numCleanedItems == numItemsInPayloadMaps {
+			if scResult.NumCleanedItems == numItemsInPayloadMaps {
 				t.Log(msg, checkMark)
 			} else {
-				t.Fatal(msg, ballotX, scResult.numCleanedItems)
+				t.Fatal(msg, ballotX, scResult.NumCleanedItems)
 			}
 
 			msg = "\t\tunlock must have been invoked once on map cleaners sync map"
@@ -2747,17 +2749,17 @@ func TestRunGenericSingleClean(t *testing.T) {
 			scResult := runGenericSingleClean(mc.ctx, mc.cih, mc.t, mapCleanersSyncMapName, payloadMapName, HzMapService, mc.retrieveAndClean)
 
 			msg := "\t\tno error must be returned"
-			if scResult.err == nil {
+			if scResult.Err == nil {
 				t.Log(msg, checkMark)
 			} else {
 				t.Fatal(msg, ballotX)
 			}
 
 			msg = "\t\treported number of cleaned items must be equal to number of items previously held by payload map"
-			if scResult.numCleanedItems == numItemsInPayloadMaps {
+			if scResult.NumCleanedItems == numItemsInPayloadMaps {
 				t.Log(msg, checkMark)
 			} else {
-				t.Fatal(msg, ballotX, scResult.numCleanedItems)
+				t.Fatal(msg, ballotX, scResult.NumCleanedItems)
 			}
 
 			msg = "\t\tunlock must have been invoked once on map cleaners sync map"
@@ -2815,17 +2817,17 @@ func TestRunGenericSingleClean(t *testing.T) {
 				scResult := runGenericSingleClean(dmc.ctx, dmc.cih, dmc.t, mapCleanersSyncMapName, mapPrefix+"load-0", HzMapService, dmc.retrieveAndClean)
 
 				msg := "\t\tno error must be returned"
-				if scResult.err == nil {
+				if scResult.Err == nil {
 					t.Log(msg, checkMark)
 				} else {
 					t.Fatal(msg, ballotX)
 				}
 
 				msg = "\t\tnumber of cleaned items must be reported correctly anyway"
-				if scResult.numCleanedItems == numItemsInPayloadMaps {
+				if scResult.NumCleanedItems == numItemsInPayloadMaps {
 					t.Log(msg, checkMark)
 				} else {
-					t.Fatal(msg, ballotX, scResult.numCleanedItems)
+					t.Fatal(msg, ballotX, scResult.NumCleanedItems)
 				}
 			}()
 
@@ -2999,7 +3001,7 @@ func TestRunGenericBatchClean(t *testing.T) {
 					if err == nil {
 						t.Log(msg, checkMark)
 					} else {
-						t.Fatal(msg, ballotX)
+						t.Fatal(msg, ballotX, err)
 					}
 
 					msg = "\t\t\treported number of maps cleaned must be zero"
@@ -3370,17 +3372,17 @@ func TestDefaultSingleMapCleaner_Clean(t *testing.T) {
 				scResult := mc.Clean(prefix + "load-0")
 
 				msg := "\t\t\terror must be returned"
-				if scResult.err != nil {
+				if scResult.Err != nil {
 					t.Log(msg, checkMark)
 				} else {
 					t.Fatal(msg, ballotX)
 				}
 
 				msg = "\t\t\treported number of cleaned items must be zero"
-				if scResult.numCleanedItems == 0 {
+				if scResult.NumCleanedItems == 0 {
 					t.Log(msg, checkMark)
 				} else {
-					t.Fatal(msg, ballotX, scResult.numCleanedItems)
+					t.Fatal(msg, ballotX, scResult.NumCleanedItems)
 				}
 
 			}
@@ -3405,17 +3407,17 @@ func TestDefaultSingleMapCleaner_Clean(t *testing.T) {
 				scResult := mc.Clean(prefix + "load-0")
 
 				msg := "\t\t\tno error must be returned"
-				if scResult.err == nil {
+				if scResult.Err == nil {
 					t.Log(msg, checkMark)
 				} else {
-					t.Fatal(msg, ballotX, scResult.err)
+					t.Fatal(msg, ballotX, scResult.Err)
 				}
 
 				msg = "\t\t\treported number of cleaned items must be equal to number of items previously held by payload data structure"
-				if scResult.numCleanedItems == numItemsInPayloadMaps {
+				if scResult.NumCleanedItems == numItemsInPayloadMaps {
 					t.Log(msg, checkMark)
 				} else {
-					t.Fatal(msg, ballotX, scResult.numCleanedItems)
+					t.Fatal(msg, ballotX, scResult.NumCleanedItems)
 				}
 
 				msg = "\t\t\tinformation on one cleaned data structure must have been added to cleaned data structures tracker"
@@ -3759,7 +3761,8 @@ func TestDefaultBatchMapCleaner_Clean(t *testing.T) {
 		t.Log("\twhen retrieval of object info succeeds, but get map operation fails")
 		{
 			c := &cleanerConfig{
-				enabled: true,
+				enabled:       true,
+				errorBehavior: Fail,
 			}
 			numMapObjects := 9
 			prefixes := []string{"ht_"}
@@ -3833,7 +3836,8 @@ func TestDefaultBatchMapCleaner_Clean(t *testing.T) {
 			ms.maps[erroneousEvictAllMapName].returnErrorUponEvictAll = true
 
 			c := &cleanerConfig{
-				enabled: true,
+				enabled:       true,
+				errorBehavior: Fail,
 			}
 
 			cih := &testLastCleanedInfoHandler{
@@ -3947,7 +3951,8 @@ func TestDefaultBatchMapCleaner_Clean(t *testing.T) {
 		t.Log("\twhen should clean check fails")
 		{
 			c := &cleanerConfig{
-				enabled: true,
+				enabled:       true,
+				errorBehavior: Fail,
 			}
 			numMapObjects := 9
 			prefixes := []string{"ht_"}
@@ -3991,7 +3996,8 @@ func TestDefaultBatchMapCleaner_Clean(t *testing.T) {
 		t.Log("\twhen update of last cleaned info fails")
 		{
 			c := &cleanerConfig{
-				enabled: true,
+				enabled:       true,
+				errorBehavior: Fail,
 			}
 			numMapObjects := 9
 			prefixes := []string{"ht_"}

--- a/state/cleaner_test.go
+++ b/state/cleaner_test.go
@@ -1318,7 +1318,11 @@ func TestCleanedDataStructureTracker_add(t *testing.T) {
 		t.Log("\twhen status gatherer has been correctly populated")
 		{
 			g := status.NewGatherer()
-			go g.Listen()
+
+			listenReady := make(chan struct{})
+			go g.Listen(listenReady)
+
+			<-listenReady
 
 			tracker := &CleanedDataStructureTracker{g}
 

--- a/state/cleaner_test.go
+++ b/state/cleaner_test.go
@@ -482,6 +482,65 @@ func (t *testCleanedTracker) add(_ string, _ int) {
 
 }
 
+func TestCalculateNumParallelSingleCleanWorkers(t *testing.T) {
+
+	t.Log("given the number of filtered data structures to be cleaned in total and a divisor to divide that number with")
+	{
+		t.Log("\twhen number of data structures is zero")
+		{
+			msg := "\t\tcalculated number of workers must be zero"
+
+			if calculateNumParallelSingleCleanWorkers(0, uint16(10)) == 0 {
+				t.Log(msg, checkMark)
+			} else {
+				t.Fatal(msg, ballotX)
+			}
+		}
+
+		t.Log("\twhen divisor is zero")
+		{
+			msg := "\t\tcalculated number of workers must be zero"
+
+			numDataStructures := 10
+			if calculateNumParallelSingleCleanWorkers(numDataStructures, 0) == uint16(0) {
+				t.Log(msg, checkMark)
+			} else {
+				t.Fatal(msg, ballotX)
+			}
+		}
+
+		t.Log("\twhen divisor is greater than number of filtered data structures")
+		{
+			msg := "\t\tcalculated number of workers must be one"
+
+			if calculateNumParallelSingleCleanWorkers(1, 20) == uint16(1) {
+				t.Log(msg, checkMark)
+			} else {
+				t.Fatal(msg, ballotX)
+			}
+		}
+
+		t.Log("\twhen greater-than-zero number of data structures is greater than or equal to divisor")
+		{
+			msg := "\t\tcalculated number of workers must be result of dividing number of datastructures by divisor"
+
+			for i := 1; i < 100; i += 5 {
+				numWorkers := i * 10
+				divisor := i
+				calculated := calculateNumParallelSingleCleanWorkers(numWorkers, uint16(divisor))
+
+				if int(calculated) == numWorkers/divisor {
+					t.Log(msg, checkMark, numWorkers, divisor)
+				} else {
+					t.Fatal(msg, ballotX, numWorkers, divisor, calculated)
+				}
+			}
+
+		}
+	}
+
+}
+
 func TestPerformParallelSingleCleans(t *testing.T) {
 
 	t.Log("given a list of filtered data structures and a clean function to invoke on the list's elements")

--- a/state/cleaner_test.go
+++ b/state/cleaner_test.go
@@ -510,7 +510,7 @@ func TestPerformParallelSingleCleans(t *testing.T) {
 				})
 
 				numberOfResults := 0
-				for _ = range results {
+				for range results {
 					numberOfResults++
 				}
 
@@ -544,7 +544,7 @@ func TestPerformParallelSingleCleans(t *testing.T) {
 			})
 
 			numResults := 0
-			for _ = range results {
+			for range results {
 				numResults++
 			}
 

--- a/state/cleaner_test.go
+++ b/state/cleaner_test.go
@@ -507,7 +507,7 @@ func TestPerformParallelSingleCleans(t *testing.T) {
 						t.Fatal("test setup error: no match in clean invoked tracker for given data structure name", name)
 					}
 					return SingleCleanResult{42, nil}
-				})
+				}, HzMapService)
 
 				numberOfResults := 0
 				for range results {
@@ -541,7 +541,7 @@ func TestPerformParallelSingleCleans(t *testing.T) {
 			results := performParallelSingleCleans([]hazelcastwrapper.ObjectInfo{}, Ignore, func(name string) SingleCleanResult {
 				numCleanInvocations++
 				return SingleCleanResult{}
-			})
+			}, HzMapService)
 
 			numResults := 0
 			for range results {
@@ -573,7 +573,7 @@ func TestPerformParallelSingleCleans(t *testing.T) {
 				results := performParallelSingleCleans(ois.objectInfos, Ignore, func(name string) SingleCleanResult {
 					numCleanInvocations++
 					return SingleCleanResult{err: singleCleanerCleanError}
-				})
+				}, HzMapService)
 
 				numResults := 0
 				for range results {
@@ -596,14 +596,15 @@ func TestPerformParallelSingleCleans(t *testing.T) {
 			}
 			t.Log("\t\twhen error behavior is fail")
 			{
-				numElements := 54
+				// Choose number so number of workers will be 1
+				numElements := 9
 				ois := populateTestObjectInfos(numElements, []string{"ht_"}, HzMapService)
 
 				numCleanInvocations := 0
 				results := performParallelSingleCleans(ois.objectInfos, Fail, func(name string) SingleCleanResult {
 					numCleanInvocations++
 					return SingleCleanResult{err: singleCleanerCleanError}
-				})
+				}, HzMapService)
 
 				numResults := 0
 				for range results {

--- a/state/cleaner_test.go
+++ b/state/cleaner_test.go
@@ -653,6 +653,33 @@ func TestPerformParallelSingleCleans(t *testing.T) {
 				t.Fatal(msg, ballotX, numCleanInvocations)
 			}
 		}
+		t.Log("\twhen divisor to use to calculate number of workers to perform parallel cleans is zero")
+		{
+			numCleanInvocations := 0
+			results := performParallelSingleCleans([]hazelcastwrapper.ObjectInfo{}, Ignore, func(name string) SingleCleanResult {
+				numCleanInvocations++
+				return SingleCleanResult{}
+			}, HzMapService, 0)
+
+			numResults := 0
+			for range results {
+				numResults++
+			}
+			msg := "\t\tzero results must be returned"
+
+			if numResults == 0 {
+				t.Log(msg, checkMark)
+			} else {
+				t.Fatal(msg, ballotX, numResults)
+			}
+
+			msg = "\t\tthere must have been zero single clean invocations"
+			if numCleanInvocations == 0 {
+				t.Log(msg, checkMark)
+			} else {
+				t.Fatal(msg, ballotX, numCleanInvocations)
+			}
+		}
 		t.Log("\twhen error occurs upon invocation of clean function on element in list")
 		{
 			t.Log("\t\twhen error behavior is ignore")

--- a/status/gatherer.go
+++ b/status/gatherer.go
@@ -86,9 +86,15 @@ func (g *Gatherer) AssembleStatusCopy() map[string]any {
 
 }
 
-func (g *Gatherer) Listen() {
+func (g *Gatherer) Listen(ready chan struct{}) {
 
 	g.insertSynchronously(Update{Key: updateKeyFinished, Value: false})
+
+	// Caller is thus forced to receive on the channel -- receive operation, in turn, can be used
+	// to ensure the goroutine on which the Listen method is running has been successfully scheduled
+	// and started to run prior to any other goroutines the caller might spawn and whose code
+	// expects this status.Gatherer instance to be listening
+	ready <- struct{}{}
 
 	for {
 		update := <-g.Updates

--- a/status/gatherer_test.go
+++ b/status/gatherer_test.go
@@ -82,7 +82,7 @@ func TestGatherer_ListeningStopped(t *testing.T) {
 			wg.add(1)
 			go func() {
 				defer wg.done()
-				g.Listen()
+				g.Listen(make(chan struct{}, 1))
 			}()
 
 			msg := "\t\tmethod must report listening has not stopped"
@@ -148,7 +148,7 @@ func TestGatherer_StopListen(t *testing.T) {
 			wg.add(1)
 			go func() {
 				defer wg.done()
-				g.Listen()
+				g.Listen(make(chan struct{}, 1))
 			}()
 
 			g.StopListen()
@@ -185,7 +185,7 @@ func TestGatherer_Listen(t *testing.T) {
 			wg.add(1)
 			go func() {
 				defer wg.done()
-				g.Listen()
+				g.Listen(make(chan struct{}, 1))
 			}()
 
 			// Listen performs initial insertion of key in question synchronously, so we can wait for the insert

--- a/status/gatherer_test.go
+++ b/status/gatherer_test.go
@@ -172,7 +172,7 @@ func TestGatherer_Listen(t *testing.T) {
 		t.Log("\twhen listener runs on goroutine")
 		{
 			l := &testLocker{}
-			g := &Gatherer{
+			g := &DefaultGatherer{
 				l:       l,
 				status:  map[string]any{},
 				Updates: make(chan Update),
@@ -358,7 +358,7 @@ func TestGatherer_InsertSynchronously(t *testing.T) {
 			key := "someNumberKey"
 
 			l := &testLocker{}
-			g := &Gatherer{
+			g := &DefaultGatherer{
 				l:       l,
 				status:  map[string]any{},
 				Updates: make(chan Update),


### PR DESCRIPTION
Introduces the capability to standalone state cleaners to split the work of checking and, potentially, cleaning target data structures into batches processed individually on separate goroutines.

Both standalone cleaners available as of this writing -- the map and queue cleaner -- will now each spawn `n` workers in the form of goroutines for processing the set of target data structures that match -- if configured -- a given prefix and might, therefore, be susceptible to cleaning. Here, `n` is the result of dividing the number of data structures in this set by a divisor, which is exposed by means of the `<cleaner>. parallelCleanNumDataStructuresDivisor` property, whose default value is `10`.

The complete standalone state cleaner configuration now looks like the following:

```yaml
stateCleaners:
  maps:
    enabled: true
    errorBehavior: ignore
    prefix:
      enabled: true
      prefix: "ht_"
    # Newly introduced property
    parallelCleanNumDataStructuresDivisor: 10
    cleanAgainThreshold:
      enabled: true
      thresholdMs: 30000
  queues:
    enabled: true
    errorBehavior: ignore
    prefix:
      enabled: true
      prefix: "ht_"
    # Newly introduced property
    parallelCleanNumDataStructuresDivisor: 10
    cleanAgainThreshold:
      enabled: true
      thresholdMs: 30000
```

Obviously, the amount of CPU given to the Hazeltest instance running the state cleaners that will spawn the workers limits how efficient the increase in parallelism can be -- for example, with a CPU limit of a mere 400m, increasing the parallelism level by having the state cleaner spawn more workers will not yield a tremendous decrease in the time it takes for the candidate data structures to be examined and, potentially, cleaned (in fact, the result might even be an increase given a sufficiently high context switiching overhead).

To back this up with some numbers, here's the results of some measurements I took:

* 400m CPU limit, 2.000 maps, 1 worker (divisor: 2.000) --> 7.382ms
* 400m CPU limit, 2.000 maps, 200 workers (divisor: 10) --> 5.488ms
 
Whereas:

* 1000m CPU limit, 2.000 maps, 1 worker (divisor: 2.000) --> 6.512ms
* 1000m CPU limit, 2.000 maps, 200 workers (divisor: 10) --> 1.391ms

However, even given the natural technical limitations of parallelizing work, doing so for cleaning data structures in a target Hazelcast cluster will usually yield a benefit. More importantly, it's now possible to clean even thousands of data structures in the target Hazelcast cluster assuming a sufficiently high CPU limit on the Hazeltest instance/-s that is/are doing the cleaning, and the limit to the number of data structures that can be cleaned in a reasonable time is now not the application itself anymore, but how many CPU it was given.

Closes #78.
