### PR TITLE
Introduce Data Structure Deletion As "Clean Mode" On State Cleaners

### DIFF
--- a/client/defaultConfig.yaml
+++ b/client/defaultConfig.yaml
@@ -83,6 +83,14 @@ stateCleaners:
   maps:
     # Whether this state cleaner should be enabled.
     enabled: true
+    # Whether to merely evict all entries from a target data structure once its susceptibility to cleaning has been
+    # verified, or delete the entire data structure altogether.
+    # One of 'delete' or 'evict', where 'delete' is the default.
+    # Please keep in mind that keeping data structures around might entail metadata about them kept by Hazelcast
+    # to act as "hidden input" to the next load test iteration, potentially decreasing load test repeatability.
+    # Therefore -- specifically if you intend to have your load tests generate, and act on, lots of data structures --,
+    # it is recommended to use the default, 'delete'.
+    cleanMode: delete
     # What to do about an error that occurs upon attempt to clean any of the identified data structures.
     # Can be one of 'ignore' or 'fail', where the former is the default. Usually, when a state cleaner encounters
     # an error, the cause is that the state cleaner of another Hazeltest instance currently holds the lock in the
@@ -139,6 +147,7 @@ stateCleaners:
   # See 'stateCleaners.maps' for an explanation on these properties.
   queues:
     enabled: true
+    cleanMode: delete
     errorBehavior: ignore
     prefix:
       enabled: true
@@ -315,6 +324,14 @@ mapTests:
       # 10, this property will ensure the maps the runner's test loop will act upon are cleaned of all entries before
       # the test loop starts.
       enabled: false
+      # Whether to merely evict all entries from a target map once its susceptibility to cleaning has been
+      # verified, or delete the map altogether.
+      # One of 'delete' or 'evict', where 'delete' is the default.
+      # Please keep in mind that keeping data structures around might entail metadata about them kept by Hazelcast
+      # to act as "hidden input" to the next load test iteration, potentially decreasing load test repeatability.
+      # Therefore -- specifically if you intend to have your load tests generate, and act on, lots of data structures --,
+      # it is recommended to use the default, 'delete'.
+      cleanMode: delete
       # What to do when cleaning a target map fails. Can be either 'ignore' or 'fail'. Default is 'ignore'.
       # 'ignore': Treats the error as a warning. The warning will be logged, but the map runner will
       # nonetheless start with its test loop.
@@ -515,6 +532,7 @@ mapTests:
     numRuns: 10000
     performPreRunClean:
       enabled: false
+      cleanMode: delete
       errorBehavior: ignore
       cleanAgainThreshold:
         enabled: true

--- a/client/defaultConfig.yaml
+++ b/client/defaultConfig.yaml
@@ -84,13 +84,13 @@ stateCleaners:
     # Whether this state cleaner should be enabled.
     enabled: true
     # Whether to merely evict all entries from a target data structure once its susceptibility to cleaning has been
-    # verified, or delete the entire data structure altogether.
-    # One of 'delete' or 'evict', where 'delete' is the default.
+    # verified, or destroy the entire data structure altogether.
+    # One of 'destroy' or 'evict', where 'destroy' is the default.
     # Please keep in mind that keeping data structures around might entail metadata about them kept by Hazelcast
     # to act as "hidden input" to the next load test iteration, potentially decreasing load test repeatability.
     # Therefore -- specifically if you intend to have your load tests generate, and act on, lots of data structures --,
-    # it is recommended to use the default, 'delete'.
-    cleanMode: delete
+    # it is recommended to use the default, 'destroy'.
+    cleanMode: destroy
     # What to do about an error that occurs upon attempt to clean any of the identified data structures.
     # Can be one of 'ignore' or 'fail', where the former is the default. Usually, when a state cleaner encounters
     # an error, the cause is that the state cleaner of another Hazeltest instance currently holds the lock in the
@@ -147,7 +147,7 @@ stateCleaners:
   # See 'stateCleaners.maps' for an explanation on these properties.
   queues:
     enabled: true
-    cleanMode: delete
+    cleanMode: destroy
     errorBehavior: ignore
     prefix:
       enabled: true
@@ -325,13 +325,13 @@ mapTests:
       # the test loop starts.
       enabled: false
       # Whether to merely evict all entries from a target map once its susceptibility to cleaning has been
-      # verified, or delete the map altogether.
-      # One of 'delete' or 'evict', where 'delete' is the default.
+      # verified, or destroy the map altogether.
+      # One of 'destroy' or 'evict', where 'destroy' is the default.
       # Please keep in mind that keeping data structures around might entail metadata about them kept by Hazelcast
       # to act as "hidden input" to the next load test iteration, potentially decreasing load test repeatability.
       # Therefore -- specifically if you intend to have your load tests generate, and act on, lots of data structures --,
-      # it is recommended to use the default, 'delete'.
-      cleanMode: delete
+      # it is recommended to use the default, 'destroy'.
+      cleanMode: destroy
       # What to do when cleaning a target map fails. Can be either 'ignore' or 'fail'. Default is 'ignore'.
       # 'ignore': Treats the error as a warning. The warning will be logged, but the map runner will
       # nonetheless start with its test loop.
@@ -532,7 +532,7 @@ mapTests:
     numRuns: 10000
     performPreRunClean:
       enabled: false
-      cleanMode: delete
+      cleanMode: destroy
       errorBehavior: ignore
       cleanAgainThreshold:
         enabled: true

--- a/maps/runner.go
+++ b/maps/runner.go
@@ -417,6 +417,13 @@ func (b runnerConfigBuilder) populateConfig() (*runnerConfig, error) {
 		})
 	})
 
+	var cleanMode state.DataStructureCleanMode
+	assignmentOps = append(assignmentOps, func() error {
+		return b.assigner.Assign(b.runnerKeyPath+".performPreRunClean.cleanMode", state.ValidateCleanMode, func(a any) {
+			cleanMode = state.DataStructureCleanMode(a.(string))
+		})
+	})
+
 	var errorDuringPreRunCleanBehavior state.ErrorDuringCleanBehavior
 	assignmentOps = append(assignmentOps, func() error {
 		return b.assigner.Assign(b.runnerKeyPath+".performPreRunClean.errorBehavior", state.ValidateErrorDuringCleanBehavior, func(a any) {
@@ -525,6 +532,7 @@ func (b runnerConfigBuilder) populateConfig() (*runnerConfig, error) {
 		},
 		preRunClean: &preRunCleanConfig{
 			enabled:                  performPreRunClean,
+			cleanMode:                cleanMode,
 			errorBehavior:            errorDuringPreRunCleanBehavior,
 			applyCleanAgainThreshold: applyCleanAgainThreshold,
 			cleanAgainThresholdMs:    cleanAgainThresholdMs,

--- a/maps/runner.go
+++ b/maps/runner.go
@@ -36,6 +36,7 @@ type (
 	}
 	preRunCleanConfig struct {
 		enabled                  bool
+		cleanMode                state.DataStructureCleanMode
 		errorBehavior            state.ErrorDuringCleanBehavior
 		applyCleanAgainThreshold bool
 		cleanAgainThresholdMs    uint64

--- a/maps/testloop.go
+++ b/maps/testloop.go
@@ -538,11 +538,11 @@ func runWrapper[t any](tle *testLoopExecution[t],
 	if tle.runnerConfig.preRunClean.enabled {
 		// TODO Add information collected by tracker to test loop status
 		// --> https://github.com/AntsInMyEy3sJohnson/hazeltest/issues/70
-		stateCleaner, hzService = tle.stateCleanerBuilder.Build(
-			tle.ctx,
-			tle.hzMapStore,
-			&state.CleanedDataStructureTracker{G: gatherer},
-			&state.DefaultLastCleanedInfoHandler{
+		bv := &state.SingleMapCleanerBuildValues{
+			Ctx: tle.ctx,
+			Ms:  tle.hzMapStore,
+			Tr:  &state.CleanedDataStructureTracker{G: gatherer},
+			Cih: &state.DefaultLastCleanedInfoHandler{
 				Ctx: tle.ctx,
 				Ms:  tle.hzMapStore,
 				Cfg: &state.LastCleanedInfoHandlerConfig{
@@ -550,7 +550,9 @@ func runWrapper[t any](tle *testLoopExecution[t],
 					CleanAgainThresholdMs:  tle.runnerConfig.preRunClean.cleanAgainThresholdMs,
 				},
 			},
-		)
+			Cm: rc.preRunClean.cleanMode,
+		}
+		stateCleaner, hzService = tle.stateCleanerBuilder.Build(bv)
 	}
 
 	var wg sync.WaitGroup

--- a/maps/testloop.go
+++ b/maps/testloop.go
@@ -578,6 +578,7 @@ func runWrapper[t any](tle *testLoopExecution[t],
 					lp.LogMapRunnerEvent("pre-run map eviction enabled, but encountered uninitialized state cleaner -- won't start test run for this map", tle.runnerName, log.ErrorLevel)
 					return
 				}
+				lp.LogMapRunnerEvent(fmt.Sprintf("invoking single map cleaner for map '%s' using clean mode '%s'", mapName, tle.runnerConfig.preRunClean.cleanMode), tle.runnerName, log.InfoLevel)
 				if scResult := stateCleaner.Clean(mapName); scResult.Err != nil {
 					configuredErrorBehavior := tle.runnerConfig.preRunClean.errorBehavior
 					if state.Ignore == tle.runnerConfig.preRunClean.errorBehavior {

--- a/maps/testloop_test.go
+++ b/maps/testloop_test.go
@@ -83,7 +83,7 @@ var (
 	defaultTestMapNumber      = uint16(0)
 )
 
-func (b *testSingleMapCleanerBuilder) Build(_ context.Context, _ hazelcastwrapper.MapStore, _ state.CleanedTracker, _ state.LastCleanedInfoHandler) (state.SingleCleaner, string) {
+func (b *testSingleMapCleanerBuilder) Build(_ *state.SingleMapCleanerBuildValues) (state.SingleCleaner, string) {
 
 	return b.mapCleanerToReturn, "hz:impl:mapService"
 

--- a/resources/charts/hazeltest/Chart.yaml
+++ b/resources/charts/hazeltest/Chart.yaml
@@ -4,6 +4,6 @@ description: A Helm chart for deploying Hazeltest on Kubernetes
 
 type: application
 
-version: 1.2.1-0.15.1
+version: 1.2.1-0.16.0
 
-appVersion: "0.15.1"
+appVersion: "0.16.0"

--- a/resources/charts/hazeltest/values.yaml
+++ b/resources/charts/hazeltest/values.yaml
@@ -73,6 +73,7 @@ config:
   stateCleaners:
     maps:
       enabled: true
+      cleanMode: destroy
       errorBehavior: ignore
       prefix:
         enabled: true
@@ -83,6 +84,7 @@ config:
         thresholdMs: 30000
     queues:
       enabled: true
+      cleanMode: destroy
       errorBehavior: ignore
       prefix:
         enabled: true
@@ -187,6 +189,7 @@ config:
       numRuns: 10000
       performPreRunClean:
         enabled: false
+        cleanMode: destroy
         errorBehavior: ignore
         cleanAgainThreshold:
           enabled: true
@@ -254,6 +257,7 @@ config:
           evaluateNewSizeAfterNumWriteActions: 100
       performPreRunClean:
         enabled: false
+        cleanMode: destroy
         errorBehavior: ignore
         cleanAgainThreshold:
           enabled: true

--- a/resources/charts/hazeltest/values.yaml
+++ b/resources/charts/hazeltest/values.yaml
@@ -4,8 +4,8 @@ image:
   registry: docker.io
   organization: antsinmyey3sjohnson
   repository: hazeltest
-  tag: 0.15.1
-  digest: ad97bd08556036fbe2fec7ce9da6e4b945cce24b8e520be798f5871f0b168240
+  tag: 0.16.0
+  digest: b1a19970fa051bd2a1333afffcc7b79d15c89ed1f2fa1551a1e72e890b29b347
   pullPolicy: IfNotPresent
 
 resources:

--- a/state/cleaner.go
+++ b/state/cleaner.go
@@ -81,11 +81,11 @@ type (
 		Clean(name string) SingleCleanResult
 	}
 	SingleMapCleanerBuildValues struct {
-		ctx       context.Context
-		ms        hazelcastwrapper.MapStore
-		t         CleanedTracker
-		cih       LastCleanedInfoHandler
-		cleanMode DataStructureCleanMode
+		Ctx context.Context
+		Ms  hazelcastwrapper.MapStore
+		Tr  CleanedTracker
+		Cih LastCleanedInfoHandler
+		Cm  DataStructureCleanMode
 	}
 	// SingleMapCleanerBuilder is an interface for encapsulating the capability of assembling map cleaners
 	// implementing the SingleCleaner interface. An interesting detail is perhaps that the Build methods for
@@ -424,11 +424,11 @@ func (c *DefaultBatchMapCleaner) Clean() (int, error) {
 
 	b := DefaultSingleMapCleanerBuilder{}
 	bv := &SingleMapCleanerBuildValues{
-		ctx:       c.ctx,
-		ms:        c.ms,
-		t:         c.t,
-		cih:       c.cih,
-		cleanMode: c.cfg.cleanMode,
+		Ctx: c.ctx,
+		Ms:  c.ms,
+		Tr:  c.t,
+		Cih: c.cih,
+		Cm:  c.cfg.cleanMode,
 	}
 	sc, _ := b.Build(bv)
 
@@ -508,16 +508,16 @@ func releaseLock(ctx context.Context, lockInfo mapLockInfo, hzService string) er
 func (b *DefaultSingleMapCleanerBuilder) Build(bv *SingleMapCleanerBuildValues) (SingleCleaner, string) {
 
 	cfg := &singleCleanerConfig{
-		cleanMode:   bv.cleanMode,
+		cleanMode:   bv.Cm,
 		syncMapName: mapCleanersSyncMapName,
 		hzService:   HzMapService,
 	}
 	return &DefaultSingleMapCleaner{
 		cfg: cfg,
-		ctx: bv.ctx,
-		ms:  bv.ms,
-		cih: bv.cih,
-		t:   bv.t,
+		ctx: bv.Ctx,
+		ms:  bv.Ms,
+		cih: bv.Cih,
+		t:   bv.Tr,
 	}, HzMapService
 
 }

--- a/state/cleaner.go
+++ b/state/cleaner.go
@@ -178,8 +178,8 @@ type (
 )
 
 const (
-	Delete DataStructureCleanMode = "delete"
-	Evict  DataStructureCleanMode = "evict"
+	Destroy DataStructureCleanMode = "destroy"
+	Evict   DataStructureCleanMode = "evict"
 )
 
 const (
@@ -972,10 +972,10 @@ func ValidateCleanMode(keyPath string, a any) error {
 	}
 
 	switch a {
-	case string(Delete), string(Evict):
+	case string(Destroy), string(Evict):
 		return nil
 	default:
-		return fmt.Errorf("expected clean mode to be one of '%s' or '%s', got %v", Delete, Evict, a)
+		return fmt.Errorf("expected clean mode to be one of '%s' or '%s', got %v", Destroy, Evict, a)
 	}
 }
 

--- a/state/cleaner.go
+++ b/state/cleaner.go
@@ -818,9 +818,17 @@ func (c *DefaultSingleQueueCleaner) retrieveAndClean(payloadQueueName string) (i
 
 	lp.LogStateCleanerEvent(fmt.Sprintf("payload queue '%s' currently holds %d elements -- proceeding to clean", payloadQueueName, size), HzQueueService, log.TraceLevel)
 
-	if err := queueToClean.Clear(c.ctx); err != nil {
-		lp.LogStateCleanerEvent(fmt.Sprintf("encountered error upon cleaning '%s': %v", payloadQueueName, err), HzQueueService, log.ErrorLevel)
-		return 0, err
+	if c.cfg.cleanMode == Destroy {
+		if err = queueToClean.Destroy(c.ctx); err != nil {
+			lp.LogStateCleanerEvent(fmt.Sprintf("encountered error upon destroying '%s': %v", payloadQueueName, err), HzQueueService, log.ErrorLevel)
+			return 0, err
+		}
+	} else {
+		if err = queueToClean.Clear(c.ctx); err != nil {
+			lp.LogStateCleanerEvent(fmt.Sprintf("encountered error upon cleaning '%s': %v", payloadQueueName, err), HzQueueService, log.ErrorLevel)
+			return 0, err
+		}
+
 	}
 
 	return size, nil

--- a/state/cleaner.go
+++ b/state/cleaner.go
@@ -24,7 +24,7 @@ type (
 		Build(ch hazelcastwrapper.HzClientHandler, ctx context.Context, g status.Gatherer, hzCluster string, hzMembers []string) (BatchCleaner, string, error)
 	}
 	DefaultBatchMapCleanerBuilder struct {
-		cfb cleanerConfigBuilder
+		cfb batchCleanerConfigBuilder
 	}
 	DefaultBatchMapCleaner struct {
 		ctx       context.Context
@@ -32,7 +32,7 @@ type (
 		hzCluster string
 		hzMembers []string
 		keyPath   string
-		cfg       *cleanerConfig
+		cfg       *batchCleanerConfig
 		ms        hazelcastwrapper.MapStore
 		ois       hazelcastwrapper.ObjectInfoStore
 		ch        hazelcastwrapper.HzClientHandler
@@ -40,7 +40,7 @@ type (
 		t         CleanedTracker
 	}
 	DefaultBatchQueueCleanerBuilder struct {
-		cfb cleanerConfigBuilder
+		cfb batchCleanerConfigBuilder
 	}
 	DefaultBatchQueueCleaner struct {
 		ctx       context.Context
@@ -48,7 +48,7 @@ type (
 		hzCluster string
 		hzMembers []string
 		keyPath   string
-		cfg       *cleanerConfig
+		cfg       *batchCleanerConfig
 		qs        hazelcastwrapper.QueueStore
 		ms        hazelcastwrapper.MapStore
 		ois       hazelcastwrapper.ObjectInfoStore
@@ -60,11 +60,32 @@ type (
 		numCleanedDataStructures int
 		err                      error
 	}
+	batchCleanerConfig struct {
+		enabled                               bool
+		usePrefix                             bool
+		prefix                                string
+		parallelCleanNumDataStructuresDivisor uint16
+		useCleanAgainThreshold                bool
+		cleanAgainThresholdMs                 uint64
+		cleanMode                             DataStructureCleanMode
+		errorBehavior                         ErrorDuringCleanBehavior
+	}
+	batchCleanerConfigBuilder struct {
+		keyPath string
+		a       client.ConfigPropertyAssigner
+	}
 )
 
 type (
 	SingleCleaner interface {
 		Clean(name string) SingleCleanResult
+	}
+	SingleMapCleanerBuildValues struct {
+		ctx       context.Context
+		ms        hazelcastwrapper.MapStore
+		t         CleanedTracker
+		cih       LastCleanedInfoHandler
+		cleanMode DataStructureCleanMode
 	}
 	// SingleMapCleanerBuilder is an interface for encapsulating the capability of assembling map cleaners
 	// implementing the SingleCleaner interface. An interesting detail is perhaps that the Build methods for
@@ -83,24 +104,34 @@ type (
 	// would be possible, but would lead to inefficiency. For example, why would a single cleaner initialize a
 	// new Hazelcast client if the caller already has one?)
 	SingleMapCleanerBuilder interface {
-		Build(ctx context.Context, ms hazelcastwrapper.MapStore, t CleanedTracker, cih LastCleanedInfoHandler) (SingleCleaner, string)
+		Build(bv *SingleMapCleanerBuildValues) (SingleCleaner, string)
+	}
+	DefaultSingleMapCleanerBuilder struct{}
+	DefaultSingleMapCleaner        struct {
+		cfg *singleCleanerConfig
+		ctx context.Context
+		ms  hazelcastwrapper.MapStore
+		cih LastCleanedInfoHandler
+		t   CleanedTracker
+	}
+	SingleQueueCleanerBuildValues struct {
+		ctx       context.Context
+		qs        hazelcastwrapper.QueueStore
+		ms        hazelcastwrapper.MapStore
+		t         CleanedTracker
+		cih       LastCleanedInfoHandler
+		cleanMode DataStructureCleanMode
 	}
 	// SingleQueueCleanerBuilder is an interface for encapsulating the capability of assembling queue cleaners
 	// implementing the SingleCleaner interface. Concerning why the Build method asks for so little knowledge about
 	// the target Hazelcast cluster and capabilities for accessing it, the same thoughts as on the
 	// SingleMapCleanerBuilder interface apply.
 	SingleQueueCleanerBuilder interface {
-		Build(ctx context.Context, qs hazelcastwrapper.QueueStore, ms hazelcastwrapper.MapStore, t CleanedTracker, cih LastCleanedInfoHandler) SingleCleaner
-	}
-	DefaultSingleMapCleanerBuilder struct{}
-	DefaultSingleMapCleaner        struct {
-		ctx context.Context
-		ms  hazelcastwrapper.MapStore
-		cih LastCleanedInfoHandler
-		t   CleanedTracker
+		Build(bv *SingleQueueCleanerBuildValues) SingleCleaner
 	}
 	DefaultSingleQueueCleanerBuilder struct{}
 	DefaultSingleQueueCleaner        struct {
+		cfg *singleCleanerConfig
 		ctx context.Context
 		ms  hazelcastwrapper.MapStore
 		qs  hazelcastwrapper.QueueStore
@@ -110,6 +141,11 @@ type (
 	SingleCleanResult struct {
 		NumCleanedItems int
 		Err             error
+	}
+	singleCleanerConfig struct {
+		cleanMode   DataStructureCleanMode
+		syncMapName string
+		hzService   string
 	}
 )
 
@@ -152,20 +188,6 @@ type (
 	}
 	CleanedDataStructureTracker struct {
 		G status.Gatherer
-	}
-	cleanerConfig struct {
-		enabled                               bool
-		usePrefix                             bool
-		prefix                                string
-		parallelCleanNumDataStructuresDivisor uint16
-		useCleanAgainThreshold                bool
-		cleanAgainThresholdMs                 uint64
-		cleanMode                             DataStructureCleanMode
-		errorBehavior                         ErrorDuringCleanBehavior
-	}
-	cleanerConfigBuilder struct {
-		keyPath string
-		a       client.ConfigPropertyAssigner
 	}
 	// mapLockInfo exists to signal to the caller of the check method on an implementation of
 	// LastCleanedInfoHandler that the method acquired a lock on the map represented by the map
@@ -215,7 +237,7 @@ func init() {
 func newMapCleanerBuilder() *DefaultBatchMapCleanerBuilder {
 
 	return &DefaultBatchMapCleanerBuilder{
-		cfb: cleanerConfigBuilder{
+		cfb: batchCleanerConfigBuilder{
 			keyPath: mapCleanerBasePath,
 			a:       client.DefaultConfigPropertyAssigner{},
 		},
@@ -226,7 +248,7 @@ func newMapCleanerBuilder() *DefaultBatchMapCleanerBuilder {
 func newQueueCleanerBuilder() *DefaultBatchQueueCleanerBuilder {
 
 	return &DefaultBatchQueueCleanerBuilder{
-		cfb: cleanerConfigBuilder{
+		cfb: batchCleanerConfigBuilder{
 			keyPath: queueCleanerBasePath,
 			a:       client.DefaultConfigPropertyAssigner{},
 		},
@@ -401,7 +423,14 @@ func (c *DefaultBatchMapCleaner) Clean() (int, error) {
 	}
 
 	b := DefaultSingleMapCleanerBuilder{}
-	sc, _ := b.Build(c.ctx, c.ms, c.t, c.cih)
+	bv := &SingleMapCleanerBuildValues{
+		ctx:       c.ctx,
+		ms:        c.ms,
+		t:         c.t,
+		cih:       c.cih,
+		cleanMode: c.cfg.cleanMode,
+	}
+	sc, _ := b.Build(bv)
 
 	start := time.Now()
 	numCleanedMaps, err := runGenericBatchClean(
@@ -476,13 +505,19 @@ func releaseLock(ctx context.Context, lockInfo mapLockInfo, hzService string) er
 
 }
 
-func (b *DefaultSingleMapCleanerBuilder) Build(ctx context.Context, ms hazelcastwrapper.MapStore, t CleanedTracker, cih LastCleanedInfoHandler) (SingleCleaner, string) {
+func (b *DefaultSingleMapCleanerBuilder) Build(bv *SingleMapCleanerBuildValues) (SingleCleaner, string) {
 
+	cfg := &singleCleanerConfig{
+		cleanMode:   bv.cleanMode,
+		syncMapName: mapCleanersSyncMapName,
+		hzService:   HzMapService,
+	}
 	return &DefaultSingleMapCleaner{
-		ctx: ctx,
-		ms:  ms,
-		cih: cih,
-		t:   t,
+		cfg: cfg,
+		ctx: bv.ctx,
+		ms:  bv.ms,
+		cih: bv.cih,
+		t:   bv.t,
 	}, HzMapService
 
 }
@@ -491,49 +526,50 @@ func runGenericSingleClean(
 	ctx context.Context,
 	cih LastCleanedInfoHandler,
 	t CleanedTracker,
-	syncMapName, payloadDataStructureName, hzService string,
+	payloadDataStructureName string,
+	cfg *singleCleanerConfig,
 	retrieveAndCleanFunc func(payloadDataStructureName string) (int, error),
 ) SingleCleanResult {
 
-	lockInfo, shouldClean, err := cih.check(syncMapName, payloadDataStructureName, hzService)
+	lockInfo, shouldClean, err := cih.check(cfg.syncMapName, payloadDataStructureName, cfg.hzService)
 
 	// This defer ensures that the lock on the sync map for the given payload map is always released
 	// no matter the susceptibility of the payload map for cleaning.
 	defer func() {
-		if err := releaseLock(ctx, lockInfo, hzService); err != nil {
-			lp.LogStateCleanerEvent(fmt.Sprintf("unable to release lock on '%s' for key '%s' due to error: %v", syncMapName, payloadDataStructureName, err), hzService, log.ErrorLevel)
+		if err := releaseLock(ctx, lockInfo, cfg.hzService); err != nil {
+			lp.LogStateCleanerEvent(fmt.Sprintf("unable to release lock on '%s' for key '%s' due to error: %v", cfg.syncMapName, payloadDataStructureName, err), cfg.hzService, log.ErrorLevel)
 		}
 	}()
 
 	if err != nil {
-		lp.LogStateCleanerEvent(fmt.Sprintf("unable to determine whether '%s' should be cleaned due to error: %v", payloadDataStructureName, err), hzService, log.ErrorLevel)
+		lp.LogStateCleanerEvent(fmt.Sprintf("unable to determine whether '%s' should be cleaned due to error: %v", payloadDataStructureName, err), cfg.hzService, log.ErrorLevel)
 		return SingleCleanResult{0, err}
 	}
 
 	if !shouldClean {
-		lp.LogStateCleanerEvent(fmt.Sprintf("clean not required for '%s'", payloadDataStructureName), hzService, log.TraceLevel)
+		lp.LogStateCleanerEvent(fmt.Sprintf("clean not required for '%s'", payloadDataStructureName), cfg.hzService, log.TraceLevel)
 		return SingleCleanResult{0, nil}
 	}
 
-	lp.LogStateCleanerEvent(fmt.Sprintf("determined that '%s' should be cleaned of state, commencing...", payloadDataStructureName), hzService, log.TraceLevel)
+	lp.LogStateCleanerEvent(fmt.Sprintf("determined that '%s' should be cleaned of state, commencing...", payloadDataStructureName), cfg.hzService, log.TraceLevel)
 	numItemsCleaned, err := retrieveAndCleanFunc(payloadDataStructureName)
 
 	if err != nil {
-		lp.LogStateCleanerEvent(fmt.Sprintf("encountered error upon cleaning '%s': %v", payloadDataStructureName, err), hzService, log.ErrorLevel)
+		lp.LogStateCleanerEvent(fmt.Sprintf("encountered error upon cleaning '%s': %v", payloadDataStructureName, err), cfg.hzService, log.ErrorLevel)
 		return SingleCleanResult{0, err}
 	}
 
 	if numItemsCleaned > 0 {
 		t.add(payloadDataStructureName, numItemsCleaned)
-		lp.LogStateCleanerEvent(fmt.Sprintf("successfully cleaned '%s', which held %d item/-s", payloadDataStructureName, numItemsCleaned), hzService, log.TraceLevel)
+		lp.LogStateCleanerEvent(fmt.Sprintf("successfully cleaned '%s', which held %d item/-s", payloadDataStructureName, numItemsCleaned), cfg.hzService, log.TraceLevel)
 	}
 
 	if err := cih.update(lockInfo); err != nil {
-		lp.LogStateCleanerEvent(fmt.Sprintf("encountered error upon attempt to update last cleaned info for '%s': %v", payloadDataStructureName, err), hzService, log.ErrorLevel)
+		lp.LogStateCleanerEvent(fmt.Sprintf("encountered error upon attempt to update last cleaned info for '%s': %v", payloadDataStructureName, err), cfg.hzService, log.ErrorLevel)
 		return SingleCleanResult{numItemsCleaned, err}
 	}
 
-	lp.LogStateCleanerEvent(fmt.Sprintf("last cleaned info successfully updated for '%s'", payloadDataStructureName), hzService, log.TraceLevel)
+	lp.LogStateCleanerEvent(fmt.Sprintf("last cleaned info successfully updated for '%s'", payloadDataStructureName), cfg.hzService, log.TraceLevel)
 	return SingleCleanResult{numItemsCleaned, err}
 
 }
@@ -567,9 +603,16 @@ func (c *DefaultSingleMapCleaner) retrieveAndClean(payloadMapName string) (int, 
 
 	lp.LogStateCleanerEvent(fmt.Sprintf("payload map '%s' currently holds %d elements -- proceeding to clean", payloadMapName, size), HzMapService, log.TraceLevel)
 
-	if err = mapToClean.EvictAll(c.ctx); err != nil {
-		lp.LogStateCleanerEvent(fmt.Sprintf("encountered error upon cleaning '%s': %v", payloadMapName, err), HzMapService, log.ErrorLevel)
-		return 0, err
+	if c.cfg.cleanMode == Destroy {
+		if err = mapToClean.Destroy(c.ctx); err != nil {
+			lp.LogStateCleanerEvent(fmt.Sprintf("encountered error upon destroying '%s': %v", payloadMapName, err), HzMapService, log.ErrorLevel)
+			return 0, err
+		}
+	} else {
+		if err = mapToClean.EvictAll(c.ctx); err != nil {
+			lp.LogStateCleanerEvent(fmt.Sprintf("encountered error upon cleaning '%s': %v", payloadMapName, err), HzMapService, log.ErrorLevel)
+			return 0, err
+		}
 	}
 	return size, nil
 
@@ -581,9 +624,8 @@ func (c *DefaultSingleMapCleaner) Clean(name string) SingleCleanResult {
 		c.ctx,
 		c.cih,
 		c.t,
-		mapCleanersSyncMapName,
 		name,
-		HzMapService,
+		c.cfg,
 		c.retrieveAndClean,
 	)
 
@@ -593,7 +635,7 @@ func runGenericBatchClean(
 	ctx context.Context,
 	ois hazelcastwrapper.ObjectInfoStore,
 	hzService string,
-	cfg *cleanerConfig,
+	cfg *batchCleanerConfig,
 	sc SingleCleaner,
 ) (int, error) {
 
@@ -655,7 +697,7 @@ func calculateNumParallelSingleCleanWorkers(numFilteredDataStructures int, paral
 
 func performParallelSingleCleans(
 	filteredDataStructures []hazelcastwrapper.ObjectInfo,
-	cfg *cleanerConfig,
+	cfg *batchCleanerConfig,
 	singleCleanFunc func(name string) SingleCleanResult,
 	hzService string,
 ) <-chan SingleCleanResult {
@@ -729,14 +771,20 @@ func performParallelSingleCleans(
 
 }
 
-func (b *DefaultSingleQueueCleanerBuilder) Build(ctx context.Context, qs hazelcastwrapper.QueueStore, ms hazelcastwrapper.MapStore, t CleanedTracker, cih LastCleanedInfoHandler) (SingleCleaner, string) {
+func (b *DefaultSingleQueueCleanerBuilder) Build(bv *SingleQueueCleanerBuildValues) (SingleCleaner, string) {
 
+	cfg := &singleCleanerConfig{
+		cleanMode:   bv.cleanMode,
+		syncMapName: queueCleanersSyncMapName,
+		hzService:   HzQueueService,
+	}
 	return &DefaultSingleQueueCleaner{
-		ctx: ctx,
-		qs:  qs,
-		ms:  ms,
-		cih: cih,
-		t:   t,
+		cfg: cfg,
+		ctx: bv.ctx,
+		qs:  bv.qs,
+		ms:  bv.ms,
+		cih: bv.cih,
+		t:   bv.t,
 	}, HzQueueService
 
 }
@@ -785,9 +833,8 @@ func (c *DefaultSingleQueueCleaner) Clean(name string) SingleCleanResult {
 		c.ctx,
 		c.cih,
 		c.t,
-		queueCleanersSyncMapName,
 		name,
-		HzQueueService,
+		c.cfg,
 		c.retrieveAndClean,
 	)
 
@@ -805,7 +852,14 @@ func (c *DefaultBatchQueueCleaner) Clean() (int, error) {
 	}
 
 	b := DefaultSingleQueueCleanerBuilder{}
-	sc, _ := b.Build(c.ctx, c.qs, c.ms, c.t, c.cih)
+	sc, _ := b.Build(&SingleQueueCleanerBuildValues{
+		ctx:       c.ctx,
+		qs:        c.qs,
+		ms:        c.ms,
+		t:         c.t,
+		cih:       c.cih,
+		cleanMode: c.cfg.cleanMode,
+	})
 
 	start := time.Now()
 	numCleaned, err := runGenericBatchClean(
@@ -886,7 +940,7 @@ func RunCleaners(hzCluster string, hzMembers []string) error {
 
 }
 
-func (b cleanerConfigBuilder) populateConfig() (*cleanerConfig, error) {
+func (b batchCleanerConfigBuilder) populateConfig() (*batchCleanerConfig, error) {
 
 	var assignmentOps []func() error
 
@@ -952,7 +1006,7 @@ func (b cleanerConfigBuilder) populateConfig() (*cleanerConfig, error) {
 		}
 	}
 
-	return &cleanerConfig{
+	return &batchCleanerConfig{
 		enabled:                               enabled,
 		cleanMode:                             cleanMode,
 		usePrefix:                             usePrefix,

--- a/state/cleaner.go
+++ b/state/cleaner.go
@@ -391,11 +391,11 @@ func (cih *DefaultLastCleanedInfoHandler) check(syncMapName, payloadDataStructur
 	cleanAgainThresholdMs := cih.Cfg.CleanAgainThresholdMs
 	lp.LogStateCleanerEvent(fmt.Sprintf("successfully retrieved last updated info from sync map '%s' for payload data structure '%s'; last updated at %d", syncMapName, payloadDataStructureName, lastCleanedAt), hzService, log.TraceLevel)
 	if time.Since(time.Unix(lastCleanedAt, 0)) < time.Millisecond*time.Duration(cleanAgainThresholdMs) {
-		lp.LogStateCleanerEvent(fmt.Sprintf("determined that difference between last cleaned timestamp and current time is less than configured threshold of '%d' milliseconds for payload data structure '%s'-- negative cleaning suggestion", cleanAgainThresholdMs, payloadDataStructureName), hzService, log.TraceLevel)
+		lp.LogStateCleanerEvent(fmt.Sprintf("determined that difference between last cleaned timestamp and current time is less than configured threshold of '%d' millisecond/-s for payload data structure '%s'-- negative cleaning suggestion", cleanAgainThresholdMs, payloadDataStructureName), hzService, log.TraceLevel)
 		return lockInfo, false, nil
 	}
 
-	lp.LogStateCleanerEvent(fmt.Sprintf("determined that difference between last cleaned timestamp and current time is greater than or equal to configured threshold of '%d' milliseconds for payload data structure '%s'-- positive cleaning suggestion", cleanAgainThresholdMs, payloadDataStructureName), hzService, log.TraceLevel)
+	lp.LogStateCleanerEvent(fmt.Sprintf("determined that difference between last cleaned timestamp and current time is greater than or equal to configured threshold of '%d' millisecond/-s for payload data structure '%s'-- positive cleaning suggestion", cleanAgainThresholdMs, payloadDataStructureName), hzService, log.TraceLevel)
 	return lockInfo, true, nil
 
 }

--- a/state/cleaner_test.go
+++ b/state/cleaner_test.go
@@ -1930,7 +1930,7 @@ func TestDefaultSingleQueueCleaner_Clean(t *testing.T) {
 					ctx:       context.TODO(),
 					qs:        populateTestQueueStore(numQueueObjects, []string{prefix}, baseName, numItemsInQueues),
 					ms:        ms,
-					t:         &testCleanedTracker{},
+					t:         tr,
 					cih:       cih,
 					cleanMode: Destroy,
 				}
@@ -1956,7 +1956,7 @@ func TestDefaultSingleQueueCleaner_Clean(t *testing.T) {
 				if tr.numAddInvocations == numQueueObjects {
 					t.Log(msg, checkMark)
 				} else {
-					t.Fatal(msg, ballotX)
+					t.Fatal(msg, ballotX, tr.numAddInvocations)
 				}
 
 			}
@@ -2750,6 +2750,11 @@ func TestRunGenericSingleClean(t *testing.T) {
 				ms:  ms,
 				cih: cih,
 				t:   tr,
+				cfg: &singleCleanerConfig{
+					cleanMode:   Destroy,
+					syncMapName: mapCleanersSyncMapName,
+					hzService:   HzMapService,
+				},
 			}
 
 			scResult := mc.Clean(payloadMapName)
@@ -2812,14 +2817,14 @@ func TestRunGenericSingleClean(t *testing.T) {
 				ms:  ms,
 				cih: cih,
 				t:   tr,
+				cfg: &singleCleanerConfig{
+					cleanMode:   Evict,
+					syncMapName: mapCleanersSyncMapName,
+					hzService:   HzMapService,
+				},
 			}
 
-			cfg := &singleCleanerConfig{
-				cleanMode:   Destroy,
-				syncMapName: mapCleanersSyncMapName,
-				hzService:   HzMapService,
-			}
-			scResult := runGenericSingleClean(mc.ctx, mc.cih, mc.t, payloadMapName, cfg, mc.retrieveAndClean)
+			scResult := runGenericSingleClean(mc.ctx, mc.cih, mc.t, payloadMapName, mc.cfg, mc.retrieveAndClean)
 
 			msg := "\t\terror must be returned"
 			if errors.Is(scResult.Err, mapEvictAllError) {
@@ -2883,6 +2888,11 @@ func TestRunGenericSingleClean(t *testing.T) {
 				ms:  ms,
 				cih: cih,
 				t:   tr,
+				cfg: &singleCleanerConfig{
+					cleanMode:   Destroy,
+					syncMapName: mapCleanersSyncMapName,
+					hzService:   HzMapService,
+				},
 			}
 
 			scResult := mc.Clean(mapPrefix + "load-0")
@@ -2944,14 +2954,14 @@ func TestRunGenericSingleClean(t *testing.T) {
 				ms:  ms,
 				cih: cih,
 				t:   tr,
+				cfg: &singleCleanerConfig{
+					cleanMode:   Destroy,
+					syncMapName: mapCleanersSyncMapName,
+					hzService:   HzMapService,
+				},
 			}
 
-			cfg := &singleCleanerConfig{
-				cleanMode:   Destroy,
-				syncMapName: mapCleanersSyncMapName,
-				hzService:   HzMapService,
-			}
-			scResult := runGenericSingleClean(mc.ctx, mc.cih, mc.t, payloadMapName, cfg, mc.retrieveAndClean)
+			scResult := runGenericSingleClean(mc.ctx, mc.cih, mc.t, payloadMapName, mc.cfg, mc.retrieveAndClean)
 
 			msg := "\t\terror must be returned"
 			if errors.Is(scResult.Err, lastCleanedInfoUpdateError) {
@@ -3010,14 +3020,13 @@ func TestRunGenericSingleClean(t *testing.T) {
 				ms:  ms,
 				cih: cih,
 				t:   tr,
+				cfg: &singleCleanerConfig{
+					cleanMode:   Destroy,
+					syncMapName: mapCleanersSyncMapName,
+					hzService:   HzMapService,
+				},
 			}
-
-			cfg := &singleCleanerConfig{
-				cleanMode:   Destroy,
-				syncMapName: mapCleanersSyncMapName,
-				hzService:   HzMapService,
-			}
-			scResult := runGenericSingleClean(mc.ctx, mc.cih, mc.t, payloadMapName, cfg, mc.retrieveAndClean)
+			scResult := runGenericSingleClean(mc.ctx, mc.cih, mc.t, payloadMapName, mc.cfg, mc.retrieveAndClean)
 
 			msg := "\t\tno error must be returned"
 			if scResult.Err == nil {

--- a/state/cleaner_test.go
+++ b/state/cleaner_test.go
@@ -3659,9 +3659,13 @@ func TestDefaultSingleMapCleaner_retrieveAndClean(t *testing.T) {
 					ms := populateTestMapStore(1, []string{prefix}, numItemsInPayloadMaps)
 
 					mc := &DefaultSingleMapCleaner{
+						cfg: &singleCleanerConfig{
+							cleanMode:   Evict,
+							syncMapName: mapCleanersSyncMapName,
+							hzService:   HzMapService,
+						},
 						ctx: context.TODO(),
 						ms:  ms,
-						cih: nil,
 					}
 
 					payloadMapName := prefix + "load-0"
@@ -3674,20 +3678,19 @@ func TestDefaultSingleMapCleaner_retrieveAndClean(t *testing.T) {
 						t.Fatal(msg, ballotX, err)
 					}
 
-					payloadMap := ms.maps[payloadMapName]
+					msg = "\t\t\t\treported number of cleaned items must be equal to number of items previously held by payload map"
+					if numCleanedItems == numItemsInPayloadMaps {
+						t.Log(msg, checkMark)
+					} else {
+						t.Fatal(msg, ballotX, numCleanedItems)
+					}
 
+					payloadMap := ms.maps[payloadMapName]
 					msg = "\t\t\t\tevict all on payload map must have been attempted once"
 					if payloadMap.evictAllInvocations == 1 {
 						t.Log(msg, checkMark)
 					} else {
 						t.Fatal(msg, ballotX)
-					}
-
-					msg = "\t\t\t\treported number of cleaned items must be equal to number of items map previously held"
-					if numCleanedItems == numItemsInPayloadMaps {
-						t.Log(msg, checkMark)
-					} else {
-						t.Fatal(msg, ballotX, numCleanedItems)
 					}
 				}
 			}

--- a/state/cleaner_test.go
+++ b/state/cleaner_test.go
@@ -176,7 +176,7 @@ var (
 	cleanerKeyPath = "stateCleaners.test"
 	testConfig     = map[string]any{
 		cleanerKeyPath + ".enabled":                               true,
-		cleanerKeyPath + ".cleanMode":                             string(Delete),
+		cleanerKeyPath + ".cleanMode":                             string(Destroy),
 		cleanerKeyPath + ".prefix.enabled":                        true,
 		cleanerKeyPath + ".prefix.prefix":                         "awesome_prefix_",
 		cleanerKeyPath + ".parallelCleanNumDataStructuresDivisor": 10,
@@ -808,7 +808,7 @@ func TestValidateCleanMode(t *testing.T) {
 		t.Log("\twhen value is string representing either of known cleaning modes")
 		{
 			msg := "no error must be returned"
-			for _, v := range []string{string(Delete), string(Evict)} {
+			for _, v := range []string{string(Destroy), string(Evict)} {
 				err := ValidateCleanMode(keyPath, v)
 
 				if err == nil {
@@ -4964,7 +4964,7 @@ func assembleTestConfig(basePath string) map[string]any {
 
 	return map[string]any{
 		basePath + ".enabled":                               true,
-		basePath + ".cleanMode":                             string(Delete),
+		basePath + ".cleanMode":                             string(Destroy),
 		basePath + ".errorBehavior":                         "ignore",
 		basePath + ".prefix.enabled":                        true,
 		basePath + ".prefix.prefix":                         "ht_",

--- a/state/cleaner_test.go
+++ b/state/cleaner_test.go
@@ -2606,17 +2606,17 @@ func TestRunGenericSingleClean(t *testing.T) {
 				},
 			}
 			bv := &SingleMapCleanerBuildValues{
-				ctx:       context.TODO(),
-				ms:        ms,
-				t:         tr,
-				cih:       cih,
-				cleanMode: Destroy,
+				Ctx: context.TODO(),
+				Ms:  ms,
+				Tr:  tr,
+				Cih: cih,
+				Cm:  Destroy,
 			}
 			mc, _ := b.Build(bv)
 			dmc := mc.(*DefaultSingleMapCleaner)
 
 			cfg := &singleCleanerConfig{
-				cleanMode:   bv.cleanMode,
+				cleanMode:   bv.Cm,
 				syncMapName: mapCleanersSyncMapName,
 				hzService:   HzMapService,
 			}
@@ -3091,11 +3091,11 @@ func TestRunGenericSingleClean(t *testing.T) {
 					Cfg: &LastCleanedInfoHandlerConfig{},
 				}
 				bv := &SingleMapCleanerBuildValues{
-					ctx:       context.TODO(),
-					ms:        ms,
-					t:         &testCleanedTracker{},
-					cih:       cih,
-					cleanMode: Destroy,
+					Ctx: context.TODO(),
+					Ms:  ms,
+					Tr:  &testCleanedTracker{},
+					Cih: cih,
+					Cm:  Destroy,
 				}
 				mc, _ := builder.Build(bv)
 
@@ -3576,6 +3576,11 @@ func TestDefaultSingleMapCleaner_retrieveAndClean(t *testing.T) {
 				ctx: context.TODO(),
 				ms:  ms,
 				cih: nil,
+				cfg: &singleCleanerConfig{
+					cleanMode:   Evict,
+					syncMapName: queueCleanersSyncMapName,
+					hzService:   HzQueueService,
+				},
 			}
 
 			numCleanedItems, err := mc.retrieveAndClean(payloadMapName)
@@ -3690,11 +3695,11 @@ func TestDefaultSingleMapCleaner_Clean(t *testing.T) {
 					Ms: ms,
 				}
 				bv := &SingleMapCleanerBuildValues{
-					ctx:       context.TODO(),
-					ms:        ms,
-					t:         &testCleanedTracker{},
-					cih:       cih,
-					cleanMode: Destroy,
+					Ctx: context.TODO(),
+					Ms:  ms,
+					Tr:  &testCleanedTracker{},
+					Cih: cih,
+					Cm:  Destroy,
 				}
 				mc, _ := builder.Build(bv)
 
@@ -3732,11 +3737,11 @@ func TestDefaultSingleMapCleaner_Clean(t *testing.T) {
 					Cfg: &LastCleanedInfoHandlerConfig{},
 				}
 				bv := &SingleMapCleanerBuildValues{
-					ctx:       context.TODO(),
-					ms:        ms,
-					t:         tr,
-					cih:       cih,
-					cleanMode: Destroy,
+					Ctx: context.TODO(),
+					Ms:  ms,
+					Tr:  tr,
+					Cih: cih,
+					Cm:  Destroy,
 				}
 				mc, _ := builder.Build(bv)
 
@@ -4653,11 +4658,11 @@ func TestDefaultSingleMapCleanerBuilder_Build(t *testing.T) {
 				Ms: ms,
 			}
 			bv := &SingleMapCleanerBuildValues{
-				ctx:       ctx,
-				ms:        ms,
-				t:         tr,
-				cih:       cih,
-				cleanMode: Destroy,
+				Ctx: ctx,
+				Ms:  ms,
+				Tr:  tr,
+				Cih: cih,
+				Cm:  Destroy,
 			}
 			cleaner, hzService := builder.Build(bv)
 

--- a/state/cleaner_test.go
+++ b/state/cleaner_test.go
@@ -176,6 +176,7 @@ var (
 	cleanerKeyPath = "stateCleaners.test"
 	testConfig     = map[string]any{
 		cleanerKeyPath + ".enabled":                               true,
+		cleanerKeyPath + ".cleanMode":                             "Delete",
 		cleanerKeyPath + ".prefix.enabled":                        true,
 		cleanerKeyPath + ".prefix.prefix":                         "awesome_prefix_",
 		cleanerKeyPath + ".parallelCleanNumDataStructuresDivisor": 10,
@@ -779,6 +780,47 @@ func TestPerformParallelSingleCleans(t *testing.T) {
 
 }
 
+func TestValidateCleanMode(t *testing.T) {
+	t.Log("given a value to configure the mode for cleaning a target data structure")
+	{
+		keyPath := "throw.me.but.dont.tell.the.elf"
+		t.Log("\twhen given value is empty string")
+		{
+			err := ValidateCleanMode(keyPath, "")
+
+			msg := "\t\terror must be returned"
+			if err != nil {
+				t.Log(msg, checkMark)
+			} else {
+				t.Fatal(msg, ballotX)
+			}
+		}
+		t.Log("\twhen value is string representing unknown cleaning mode")
+		{
+			err := ValidateCleanMode(keyPath, "A wizard is never late, nor is he early, he arrives precisely when he means to.")
+			msg := "\t\terror must be returned"
+			if err != nil {
+				t.Log(msg, checkMark)
+			} else {
+				t.Fatal(msg, ballotX)
+			}
+		}
+		t.Log("\twhen value is string representing either of known cleaning modes")
+		{
+			msg := "no error must be returned"
+			for _, v := range []string{string(Delete), string(Evict)} {
+				err := ValidateCleanMode(keyPath, v)
+
+				if err == nil {
+					t.Log(msg, checkMark, v)
+				} else {
+					t.Fatal(msg, ballotX, v)
+				}
+			}
+		}
+	}
+}
+
 func TestValidateErrorDuringCleanBehavior(t *testing.T) {
 
 	t.Log("given a value to configure pre-run clean error behavior")
@@ -794,7 +836,6 @@ func TestValidateErrorDuringCleanBehavior(t *testing.T) {
 			} else {
 				t.Fatal(msg, ballotX)
 			}
-
 		}
 
 		t.Log("\twhen value is string representing unknown behavior")

--- a/state/cleaner_test.go
+++ b/state/cleaner_test.go
@@ -3772,7 +3772,51 @@ func TestDefaultSingleMapCleaner_retrieveAndClean(t *testing.T) {
 				}
 				t.Log("\t\t\twhen destroy does not yield error")
 				{
-					t.Fatal("implement me")
+					prefix := "ht_"
+					numItemsInPayloadMaps := 6
+					ms := populateTestMapStore(18, []string{prefix}, 6)
+					payloadMapName := prefix + "load-0"
+					payloadMap := ms.maps[payloadMapName]
+
+					mc := &DefaultSingleMapCleaner{
+						cfg: &singleCleanerConfig{
+							cleanMode:   Destroy,
+							syncMapName: mapCleanersSyncMapName,
+							hzService:   HzMapService,
+						},
+						ctx: context.TODO(),
+						ms:  ms,
+					}
+
+					numCleanedItems, err := mc.retrieveAndClean(payloadMapName)
+
+					msg := "\t\t\t\tno error must be returned"
+					if err == nil {
+						t.Log(msg, checkMark)
+					} else {
+						t.Fatal(msg, ballotX)
+					}
+
+					msg = "\t\t\t\treported number of cleaned items must be equal to number of items previously held by payload map"
+					if numCleanedItems == numItemsInPayloadMaps {
+						t.Log(msg, checkMark)
+					} else {
+						t.Fatal(msg, ballotX, numCleanedItems)
+					}
+
+					msg = "\t\t\t\tthere must have been no attempts to perform a map eviction"
+					if payloadMap.evictAllInvocations == 0 {
+						t.Log(msg, checkMark)
+					} else {
+						t.Fatal(msg, ballotX, payloadMap.evictAllInvocations)
+					}
+
+					msg = "\t\t\t\tthere must have been one attempt to destroy the map"
+					if payloadMap.destroyInvocations == 1 {
+						t.Log(msg, checkMark)
+					} else {
+						t.Fatal(msg, ballotX, payloadMap.destroyInvocations)
+					}
 				}
 			}
 		}

--- a/state/cleaner_test.go
+++ b/state/cleaner_test.go
@@ -1784,83 +1784,100 @@ func TestDefaultSingleQueueCleaner_retrieveAndClean(t *testing.T) {
 			}
 
 		}
-		t.Log("\twhen retrieval of non-nil queue is successful, but queue clear operation yields error")
+		t.Log("\twhen retrieval of non-nil queue is successful")
 		{
-			prefix := "ht_"
-			baseName := "load"
-			qs := populateTestQueueStore(1, []string{prefix}, baseName, 1)
+			t.Log("\t\twhen clean mode is evict")
+			{
+				t.Log("\t\t\twhen evict yields error")
+				{
+					prefix := "ht_"
+					baseName := "load"
+					qs := populateTestQueueStore(1, []string{prefix}, baseName, 1)
 
-			payloadQueueName := prefix + baseName + "-0"
-			payloadQueue := qs.queues[payloadQueueName]
-			payloadQueue.returnErrorUponClear = true
+					payloadQueueName := prefix + baseName + "-0"
+					payloadQueue := qs.queues[payloadQueueName]
+					payloadQueue.returnErrorUponClear = true
 
-			qc := &DefaultSingleQueueCleaner{
-				ctx: context.TODO(),
-				qs:  qs,
+					qc := &DefaultSingleQueueCleaner{
+						ctx: context.TODO(),
+						qs:  qs,
+					}
+
+					numCleanedItems, err := qc.retrieveAndClean(payloadQueueName)
+
+					msg := "\t\terror must be returned"
+
+					if errors.Is(err, queueClearError) {
+						t.Log(msg, checkMark)
+					} else {
+						t.Fatal(msg, ballotX)
+					}
+
+					msg = "\t\treported number of cleaned items must be zero"
+					if numCleanedItems == 0 {
+						t.Log(msg, checkMark)
+					} else {
+						t.Fatal(msg, ballotX, numCleanedItems)
+					}
+
+					msg = "\t\tclear on payload queue must have been attempted once"
+					if payloadQueue.clearInvocations == 1 {
+						t.Log(msg, checkMark)
+					} else {
+						t.Fatal(msg, ballotX, payloadQueue.clearInvocations)
+					}
+				}
+
+				t.Log("\t\t\twhen evict does not yield error")
+				{
+					prefix := "ht_"
+					baseName := "load"
+					numItemsInQueues := 9
+					qs := populateTestQueueStore(1, []string{prefix}, baseName, numItemsInQueues)
+
+					qc := &DefaultSingleQueueCleaner{
+						ctx: context.TODO(),
+						ms:  nil,
+						qs:  qs,
+						cih: nil,
+					}
+
+					payloadQueueName := prefix + baseName + "-0"
+					numCleanedItems, err := qc.retrieveAndClean(payloadQueueName)
+
+					payloadQueue := qs.queues[payloadQueueName]
+
+					msg := "\t\tno error must be returned"
+					if err == nil {
+						t.Log(msg, checkMark)
+					} else {
+						t.Fatal(msg, ballotX)
+					}
+
+					msg = "\t\treported number of cleaned items must be equal to number of items previously in queue"
+					if numCleanedItems == numItemsInQueues {
+						t.Log(msg, checkMark)
+					} else {
+						t.Fatal(msg, ballotX, numCleanedItems)
+					}
+
+					msg = "\t\tclear on payload queue must have been performed once"
+					if payloadQueue.clearInvocations == 1 {
+						t.Log(msg, checkMark)
+					} else {
+						t.Fatal(msg, ballotX, payloadQueue.clearInvocations)
+					}
+				}
 			}
+			t.Log("\t\twhen clean mode is destroy")
+			{
+				t.Log("\t\t\twhen destroy yields error")
+				{
+				}
 
-			numCleanedItems, err := qc.retrieveAndClean(payloadQueueName)
-
-			msg := "\t\terror must be returned"
-
-			if errors.Is(err, queueClearError) {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX)
-			}
-
-			msg = "\t\treported number of cleaned items must be zero"
-			if numCleanedItems == 0 {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX, numCleanedItems)
-			}
-
-			msg = "\t\tclear on payload queue must have been attempted once"
-			if payloadQueue.clearInvocations == 1 {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX, payloadQueue.clearInvocations)
-			}
-		}
-		t.Log("\twhen retrieval of non-nil queue is successful and queue clear operation does not yield error")
-		{
-			prefix := "ht_"
-			baseName := "load"
-			numItemsInQueues := 9
-			qs := populateTestQueueStore(1, []string{prefix}, baseName, numItemsInQueues)
-
-			qc := &DefaultSingleQueueCleaner{
-				ctx: context.TODO(),
-				ms:  nil,
-				qs:  qs,
-				cih: nil,
-			}
-
-			payloadQueueName := prefix + baseName + "-0"
-			numCleanedItems, err := qc.retrieveAndClean(payloadQueueName)
-
-			payloadQueue := qs.queues[payloadQueueName]
-
-			msg := "\t\tno error must be returned"
-			if err == nil {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX)
-			}
-
-			msg = "\t\treported number of cleaned items must be equal to number of items previously in queue"
-			if numCleanedItems == numItemsInQueues {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX, numCleanedItems)
-			}
-
-			msg = "\t\tclear on payload queue must have been performed once"
-			if payloadQueue.clearInvocations == 1 {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX, payloadQueue.clearInvocations)
+				t.Log("\t\t\twhen destroy does not yield error")
+				{
+				}
 			}
 		}
 	}

--- a/state/cleaner_test.go
+++ b/state/cleaner_test.go
@@ -35,7 +35,7 @@ type (
 	}
 	testSingleCleaner struct {
 		behavior *testCleanerBehavior
-		cfg      *cleanerConfig
+		cfg      *batchCleanerConfig
 	}
 	cleanerWatcher struct {
 		m                      sync.Mutex
@@ -931,7 +931,7 @@ func TestPopulateConfig(t *testing.T) {
 	{
 		t.Log("\twhen assignment operation yields error due to invalid configuration property")
 		{
-			b := &cleanerConfigBuilder{
+			b := &batchCleanerConfigBuilder{
 				keyPath: cleanerKeyPath,
 				a: &testConfigPropertyAssigner{
 					returnErrorUponAssignConfigValue: true,
@@ -957,7 +957,7 @@ func TestPopulateConfig(t *testing.T) {
 
 		t.Log("\twhen all assignment operations are successful")
 		{
-			b := &cleanerConfigBuilder{
+			b := &batchCleanerConfigBuilder{
 				keyPath: cleanerKeyPath,
 				a: &testConfigPropertyAssigner{
 					testConfig: testConfig,
@@ -1956,7 +1956,7 @@ func TestDefaultBatchQueueCleaner_Clean(t *testing.T) {
 				testObjectInfoStore.objectInfos = append(testObjectInfoStore.objectInfos, *newQueueObjectInfoFromName(hzInternalQueueName))
 				testQueueStore.queues[hzInternalQueueName] = &testHzQueue{}
 
-				c := &cleanerConfig{
+				c := &batchCleanerConfig{
 					enabled:                               true,
 					usePrefix:                             true,
 					prefix:                                prefixToConsider,
@@ -2126,7 +2126,7 @@ func TestDefaultBatchQueueCleaner_Clean(t *testing.T) {
 				ois.objectInfos = append(ois.objectInfos, *newQueueObjectInfoFromName(hzInternalQueueName))
 				qs.queues[hzInternalQueueName] = &testHzQueue{}
 
-				c := &cleanerConfig{
+				c := &batchCleanerConfig{
 					enabled:                               true,
 					parallelCleanNumDataStructuresDivisor: 10,
 				}
@@ -2193,7 +2193,7 @@ func TestDefaultBatchQueueCleaner_Clean(t *testing.T) {
 		}
 		t.Log("\twhen target hazelcast cluster does not contain any queues")
 		{
-			c := &cleanerConfig{
+			c := &batchCleanerConfig{
 				enabled: true,
 			}
 			qs := &testHzQueueStore{queues: make(map[string]*testHzQueue)}
@@ -2241,7 +2241,7 @@ func TestDefaultBatchQueueCleaner_Clean(t *testing.T) {
 		}
 		t.Log("\twhen retrieval of object info fails")
 		{
-			c := &cleanerConfig{
+			c := &batchCleanerConfig{
 				enabled: true,
 			}
 			ois := &testHzObjectInfoStore{
@@ -2279,7 +2279,7 @@ func TestDefaultBatchQueueCleaner_Clean(t *testing.T) {
 		}
 		t.Log("\twhen retrieval of object info succeeds, but get queue operation fails")
 		{
-			c := &cleanerConfig{
+			c := &batchCleanerConfig{
 				enabled:                               true,
 				parallelCleanNumDataStructuresDivisor: 10,
 				errorBehavior:                         Fail,
@@ -2356,7 +2356,7 @@ func TestDefaultBatchQueueCleaner_Clean(t *testing.T) {
 			erroneousClearQueueName := prefixes[0] + baseName + "-0"
 			qs.queues[erroneousClearQueueName].returnErrorUponClear = true
 
-			c := &cleanerConfig{
+			c := &batchCleanerConfig{
 				enabled:                               true,
 				parallelCleanNumDataStructuresDivisor: 10,
 				errorBehavior:                         Fail,
@@ -2426,7 +2426,7 @@ func TestDefaultBatchQueueCleaner_Clean(t *testing.T) {
 		}
 		t.Log("\twhen cleaner has not been enabled")
 		{
-			c := &cleanerConfig{
+			c := &batchCleanerConfig{
 				enabled: false,
 			}
 			qs := &testHzQueueStore{}
@@ -3044,7 +3044,7 @@ func TestRunGenericBatchClean(t *testing.T) {
 				ois.returnErrorUponGetObjectInfos = true
 
 				sc := &testSingleCleaner{
-					cfg: &cleanerConfig{},
+					cfg: &batchCleanerConfig{},
 				}
 
 				numMapsCleaned, err := runGenericBatchClean(context.TODO(), ois, HzMapService, sc.cfg, sc)
@@ -3078,7 +3078,7 @@ func TestRunGenericBatchClean(t *testing.T) {
 				ois := populateTestObjectInfos(0, []string{}, HzMapService)
 
 				sc := &testSingleCleaner{
-					cfg: &cleanerConfig{},
+					cfg: &batchCleanerConfig{},
 				}
 
 				numMapsCleaned, err := runGenericBatchClean(context.TODO(), ois, HzMapService, sc.cfg, sc)
@@ -3117,7 +3117,7 @@ func TestRunGenericBatchClean(t *testing.T) {
 					behavior: &testCleanerBehavior{
 						numItemsCleanedReturnValue: 1,
 					},
-					cfg: &cleanerConfig{
+					cfg: &batchCleanerConfig{
 						parallelCleanNumDataStructuresDivisor: 10,
 					},
 				}
@@ -3152,7 +3152,7 @@ func TestRunGenericBatchClean(t *testing.T) {
 					behavior: &testCleanerBehavior{
 						numItemsCleanedReturnValue: 1,
 					},
-					cfg: &cleanerConfig{
+					cfg: &batchCleanerConfig{
 						usePrefix:                             true,
 						prefix:                                prefixToConsider,
 						parallelCleanNumDataStructuresDivisor: 10,
@@ -3190,7 +3190,7 @@ func TestRunGenericBatchClean(t *testing.T) {
 						behavior: &testCleanerBehavior{
 							returnErrorUponClean: true,
 						},
-						cfg: &cleanerConfig{
+						cfg: &batchCleanerConfig{
 							parallelCleanNumDataStructuresDivisor: 10,
 							errorBehavior:                         Ignore,
 						},
@@ -3232,7 +3232,7 @@ func TestRunGenericBatchClean(t *testing.T) {
 							numItemsCleanedReturnValue: 9,
 							returnErrorUponClean:       true,
 						},
-						cfg: &cleanerConfig{
+						cfg: &batchCleanerConfig{
 							parallelCleanNumDataStructuresDivisor: 10,
 							errorBehavior:                         Ignore,
 						},
@@ -3277,7 +3277,7 @@ func TestRunGenericBatchClean(t *testing.T) {
 						returnCleanErrorAfterNoInvocations: 3,
 						returnErrorUponClean:               true,
 					},
-					cfg: &cleanerConfig{
+					cfg: &batchCleanerConfig{
 						parallelCleanNumDataStructuresDivisor: 10,
 						errorBehavior:                         Fail,
 					},
@@ -3325,7 +3325,7 @@ func TestRunGenericBatchClean(t *testing.T) {
 						// anyway to convey why we expect zero maps reported to be cleaned
 						numItemsCleanedReturnValue: 0,
 					},
-					cfg: &cleanerConfig{
+					cfg: &batchCleanerConfig{
 						parallelCleanNumDataStructuresDivisor: 10,
 					},
 				}
@@ -3366,7 +3366,7 @@ func TestRunGenericBatchClean(t *testing.T) {
 					behavior: &testCleanerBehavior{
 						numItemsCleanedReturnValue: 1,
 					},
-					cfg: &cleanerConfig{
+					cfg: &batchCleanerConfig{
 						parallelCleanNumDataStructuresDivisor: 10,
 					},
 				}
@@ -3507,45 +3507,65 @@ func TestDefaultSingleMapCleaner_retrieveAndClean(t *testing.T) {
 			}
 		}
 
-		t.Log("\twhen get payload map is successful, retrieved map is non-nil, and evict does not yield error")
+		t.Log("\twhen get payload map is successful, retrieved map is non-nil")
 		{
+			t.Log("\t\twhen clean mode is evict")
+			{
+				t.Log("\t\t\twhen evict yields error")
+				{
+					t.Fatal("implement me")
+				}
+				t.Log("\t\t\twhen evict does not yield error")
+				{
+					prefix := "ht_"
+					numItemsInPayloadMaps := 9
+					ms := populateTestMapStore(1, []string{prefix}, numItemsInPayloadMaps)
 
-			prefix := "ht_"
-			numItemsInPayloadMaps := 9
-			ms := populateTestMapStore(1, []string{prefix}, numItemsInPayloadMaps)
+					mc := &DefaultSingleMapCleaner{
+						ctx: context.TODO(),
+						ms:  ms,
+						cih: nil,
+					}
 
-			mc := &DefaultSingleMapCleaner{
-				ctx: context.TODO(),
-				ms:  ms,
-				cih: nil,
+					payloadMapName := prefix + "load-0"
+					numCleanedItems, err := mc.retrieveAndClean(payloadMapName)
+
+					msg := "\t\t\t\tno error must be returned"
+					if err == nil {
+						t.Log(msg, checkMark)
+					} else {
+						t.Fatal(msg, ballotX, err)
+					}
+
+					payloadMap := ms.maps[payloadMapName]
+
+					msg = "\t\t\t\tevict all on payload map must have been attempted once"
+					if payloadMap.evictAllInvocations == 1 {
+						t.Log(msg, checkMark)
+					} else {
+						t.Fatal(msg, ballotX)
+					}
+
+					msg = "\t\t\t\treported number of cleaned items must be equal to number of items map previously held"
+					if numCleanedItems == numItemsInPayloadMaps {
+						t.Log(msg, checkMark)
+					} else {
+						t.Fatal(msg, ballotX, numCleanedItems)
+					}
+				}
 			}
 
-			payloadMapName := prefix + "load-0"
-			numCleanedItems, err := mc.retrieveAndClean(payloadMapName)
-
-			msg := "\t\tno error must be returned"
-			if err == nil {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX, err)
+			t.Log("\t\twhen clean mode is destroy")
+			{
+				t.Log("\t\t\twhen destroy yields error")
+				{
+					t.Fatal("implement me")
+				}
+				t.Log("\t\t\twhen destroy does not yield error")
+				{
+					t.Fatal("implement me")
+				}
 			}
-
-			payloadMap := ms.maps[payloadMapName]
-
-			msg = "\t\tevict all on payload map must have been attempted once"
-			if payloadMap.evictAllInvocations == 1 {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX)
-			}
-
-			msg = "\t\treported number of cleaned items must be equal to number of items map previously held"
-			if numCleanedItems == numItemsInPayloadMaps {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX, numCleanedItems)
-			}
-
 		}
 
 	}
@@ -3667,7 +3687,7 @@ func TestDefaultBatchMapCleaner_Clean(t *testing.T) {
 				testObjectInfoStore.objectInfos = append(testObjectInfoStore.objectInfos, *newMapObjectInfoFromName(hzInternalMapName))
 				testMapStore.maps[hzInternalMapName] = &testHzMap{data: make(map[string]any)}
 
-				c := &cleanerConfig{
+				c := &batchCleanerConfig{
 					enabled:                               true,
 					usePrefix:                             true,
 					prefix:                                prefixToConsider,
@@ -3819,7 +3839,7 @@ func TestDefaultBatchMapCleaner_Clean(t *testing.T) {
 				ois.objectInfos = append(ois.objectInfos, *newMapObjectInfoFromName(hzInternalMapName))
 				ms.maps[hzInternalMapName] = &testHzMap{data: make(map[string]any)}
 
-				c := &cleanerConfig{
+				c := &batchCleanerConfig{
 					enabled:                               true,
 					parallelCleanNumDataStructuresDivisor: 10,
 				}
@@ -3886,7 +3906,7 @@ func TestDefaultBatchMapCleaner_Clean(t *testing.T) {
 		}
 		t.Log("\twhen target hazelcast cluster does not contain any maps")
 		{
-			c := &cleanerConfig{
+			c := &batchCleanerConfig{
 				enabled: true,
 			}
 			ms := &testHzMapStore{
@@ -3935,7 +3955,7 @@ func TestDefaultBatchMapCleaner_Clean(t *testing.T) {
 		}
 		t.Log("\twhen retrieval of object info fails")
 		{
-			c := &cleanerConfig{
+			c := &batchCleanerConfig{
 				enabled: true,
 			}
 			ois := &testHzObjectInfoStore{
@@ -3969,7 +3989,7 @@ func TestDefaultBatchMapCleaner_Clean(t *testing.T) {
 		}
 		t.Log("\twhen retrieval of object info succeeds, but get map operation fails")
 		{
-			c := &cleanerConfig{
+			c := &batchCleanerConfig{
 				enabled:                               true,
 				parallelCleanNumDataStructuresDivisor: 10,
 				errorBehavior:                         Fail,
@@ -4045,7 +4065,7 @@ func TestDefaultBatchMapCleaner_Clean(t *testing.T) {
 			erroneousEvictAllMapName := "ht_load-0"
 			ms.maps[erroneousEvictAllMapName].returnErrorUponEvictAll = true
 
-			c := &cleanerConfig{
+			c := &batchCleanerConfig{
 				enabled:                               true,
 				parallelCleanNumDataStructuresDivisor: 10,
 				errorBehavior:                         Fail,
@@ -4110,7 +4130,7 @@ func TestDefaultBatchMapCleaner_Clean(t *testing.T) {
 		t.Log("\twhen should clean check yields true only for subset of data structures")
 		{
 
-			c := &cleanerConfig{
+			c := &batchCleanerConfig{
 				enabled:                               true,
 				parallelCleanNumDataStructuresDivisor: 10,
 			}
@@ -4162,7 +4182,7 @@ func TestDefaultBatchMapCleaner_Clean(t *testing.T) {
 		}
 		t.Log("\twhen should clean check fails")
 		{
-			c := &cleanerConfig{
+			c := &batchCleanerConfig{
 				enabled:                               true,
 				parallelCleanNumDataStructuresDivisor: 10,
 				errorBehavior:                         Fail,
@@ -4208,7 +4228,7 @@ func TestDefaultBatchMapCleaner_Clean(t *testing.T) {
 		}
 		t.Log("\twhen update of last cleaned info fails")
 		{
-			c := &cleanerConfig{
+			c := &batchCleanerConfig{
 				enabled:                               true,
 				parallelCleanNumDataStructuresDivisor: 10,
 				errorBehavior:                         Fail,
@@ -4249,7 +4269,7 @@ func TestDefaultBatchMapCleaner_Clean(t *testing.T) {
 		}
 		t.Log("\twhen cleaner has not been enabled")
 		{
-			c := &cleanerConfig{
+			c := &batchCleanerConfig{
 				enabled: false,
 			}
 			ms := &testHzMapStore{}
@@ -4900,7 +4920,7 @@ func TestRunCleaners(t *testing.T) {
 
 }
 
-func configValuesAsExpected(cfg *cleanerConfig, expectedValues map[string]any) (bool, string) {
+func configValuesAsExpected(cfg *batchCleanerConfig, expectedValues map[string]any) (bool, string) {
 
 	keyPath := cleanerKeyPath + ".enabled"
 	if cfg.enabled != expectedValues[keyPath].(bool) {
@@ -5068,7 +5088,7 @@ func resolveObjectKindForNameFromObjectInfoList(name string, objectInfos []hazel
 
 }
 
-func assembleBatchQueueCleaner(c *cleanerConfig, qs *testHzQueueStore, ms *testHzMapStore, ois *testHzObjectInfoStore, ch *testHzClientHandler, cih LastCleanedInfoHandler, t CleanedTracker) *DefaultBatchQueueCleaner {
+func assembleBatchQueueCleaner(c *batchCleanerConfig, qs *testHzQueueStore, ms *testHzMapStore, ois *testHzObjectInfoStore, ch *testHzClientHandler, cih LastCleanedInfoHandler, t CleanedTracker) *DefaultBatchQueueCleaner {
 
 	return &DefaultBatchQueueCleaner{
 		name:      queueCleanerName,
@@ -5086,7 +5106,7 @@ func assembleBatchQueueCleaner(c *cleanerConfig, qs *testHzQueueStore, ms *testH
 
 }
 
-func assembleBatchMapCleaner(c *cleanerConfig, ms *testHzMapStore, ois *testHzObjectInfoStore, ch *testHzClientHandler, cih LastCleanedInfoHandler, t CleanedTracker) *DefaultBatchMapCleaner {
+func assembleBatchMapCleaner(c *batchCleanerConfig, ms *testHzMapStore, ois *testHzObjectInfoStore, ch *testHzClientHandler, cih LastCleanedInfoHandler, t CleanedTracker) *DefaultBatchMapCleaner {
 
 	return &DefaultBatchMapCleaner{
 		name:      mapCleanerName,

--- a/state/cleaner_test.go
+++ b/state/cleaner_test.go
@@ -176,7 +176,7 @@ var (
 	cleanerKeyPath = "stateCleaners.test"
 	testConfig     = map[string]any{
 		cleanerKeyPath + ".enabled":                               true,
-		cleanerKeyPath + ".cleanMode":                             "Delete",
+		cleanerKeyPath + ".cleanMode":                             string(Delete),
 		cleanerKeyPath + ".prefix.enabled":                        true,
 		cleanerKeyPath + ".prefix.prefix":                         "awesome_prefix_",
 		cleanerKeyPath + ".parallelCleanNumDataStructuresDivisor": 10,
@@ -4964,6 +4964,7 @@ func assembleTestConfig(basePath string) map[string]any {
 
 	return map[string]any{
 		basePath + ".enabled":                               true,
+		basePath + ".cleanMode":                             string(Delete),
 		basePath + ".errorBehavior":                         "ignore",
 		basePath + ".prefix.enabled":                        true,
 		basePath + ".prefix.prefix":                         "ht_",


### PR DESCRIPTION
In order to prevent meta information that Hazelcast maintains on data structures from acting as hidden input to a load test -- which might jeopardize the outcome, hence decrease the tests' overall repeatability --, state cleaners must offer data structure deletion (or _destruction_) as one of their _clean modes_.

Therefore, this PR introduces the _cleanMode_ property to all state cleaners currently available in the application (standalone state cleaners for maps and queues, and runner state cleaners for map runners):

```yaml
# Example for state cleaners
stateCleaners:
  maps:
    enabled: true
    cleanMode: destroy
    # ... more stuff

# Example for runner-related cleaners
mapTests:
  pokedex:
    enabled: true
    # ...
    performPreRunClean:
      enabled: true
      cleanMode: destroy
      # ...
```

The `cleanMode` property controls whether to merely evict all entries from a target data structure once its susceptibility to cleaning has been verified. Accordingly, possible values for this property are `destroy` and `evict`, where the former is the default.

Closes #82.
