### PR TITLE
Add Missing Sleep After Delete Action Batch

### DIFF
--- a/client/defaultConfig.yaml
+++ b/client/defaultConfig.yaml
@@ -218,7 +218,7 @@ queueTests:
           enableRandomness: false
         # Causes a put goroutine to sleep after performing one batch of put operations, where the batch size is
         # configured by means of the above '(...).putConfig.batchSize' property.
-        betweenActionBatches:
+        afterActionBatch:
           enabled: true
           durationMs: 1000
           enableRandomness: true
@@ -240,7 +240,7 @@ queueTests:
           enabled: true
           durationMs: 12500
           enableRandomness: false
-        betweenActionBatches:
+        afterActionBatch:
           enabled: true
           durationMs: 1000
           enableRandomness: true
@@ -274,7 +274,7 @@ queueTests:
           enabled: false
           durationMs: 2000
           enableRandomness: false
-        betweenActionBatches:
+        afterActionBatch:
           enabled: true
           durationMs: 200
           enableRandomness: true
@@ -291,7 +291,7 @@ queueTests:
           enabled: true
           durationMs: 20000
           enableRandomness: false
-        betweenActionBatches:
+        afterActionBatch:
           enabled: true
           durationMs: 200
           enableRandomness: true
@@ -371,14 +371,17 @@ mapTests:
       batch:
         sleeps:
           # If this is enabled, the test loop will wait for <durationMs> (or a duration in the interval [1, <durationMs]
-          # in case randomness has been enabled) after execution one action in a batch (e.g. one insert operation).
+          # in case randomness has been enabled) after executing one action in a batch (e.g. one insert operation).
+          # Mind the difference between 'afterBatchAction' (this property) and 'afterActionBatch' (the property
+          # below) -- whereas the former refers to what happens after a single action within a batch of actions, the
+          # latter is concerned with what happens after that batch of actions has concluded.
           afterBatchAction:
             enabled: true
             durationMs: 50
             enableRandomness: true
           # Can be enabled to make the batch test loop sleep for the given duration after one batch of actions (e.g.,
           # "ingest x elements") has finished, meaning the next action batch will start only after a sleep of <durationMs>
-          betweenActionBatches:
+          afterActionBatch:
             enabled: true
             durationMs: 5000
             enableRandomness: true
@@ -553,7 +556,7 @@ mapTests:
             enabled: true
             durationMs: 10
             enableRandomness: true
-          betweenActionBatches:
+          afterActionBatch:
             enabled: true
             durationMs: 2000
             enableRandomness: true

--- a/maps/runner.go
+++ b/maps/runner.go
@@ -62,8 +62,8 @@ type (
 
 type (
 	batchTestLoopConfig struct {
-		sleepAfterBatchAction     *sleepConfig
-		sleepBetweenActionBatches *sleepConfig
+		sleepAfterBatchAction *sleepConfig
+		sleepAfterActionBatch *sleepConfig
 	}
 )
 
@@ -144,24 +144,24 @@ func populateBatchTestLoopConfig(b runnerConfigBuilder) (*batchTestLoopConfig, e
 		})
 	})
 
-	var sleepBetweenActionBatchesEnabled bool
+	var sleepAfterActionBatchEnabled bool
 	assignmentOps = append(assignmentOps, func() error {
-		return b.assigner.Assign(b.runnerKeyPath+".testLoop.batch.sleeps.betweenActionBatches.enabled", client.ValidateBool, func(a any) {
-			sleepBetweenActionBatchesEnabled = a.(bool)
+		return b.assigner.Assign(b.runnerKeyPath+".testLoop.batch.sleeps.afterActionBatch.enabled", client.ValidateBool, func(a any) {
+			sleepAfterActionBatchEnabled = a.(bool)
 		})
 	})
 
-	var sleepBetweenActionBatchesDurationMs int
+	var sleepAfterActionBatchDurationMs int
 	assignmentOps = append(assignmentOps, func() error {
-		return b.assigner.Assign(b.runnerKeyPath+".testLoop.batch.sleeps.betweenActionBatches.durationMs", client.ValidateInt, func(a any) {
-			sleepBetweenActionBatchesDurationMs = a.(int)
+		return b.assigner.Assign(b.runnerKeyPath+".testLoop.batch.sleeps.afterActionBatch.durationMs", client.ValidateInt, func(a any) {
+			sleepAfterActionBatchDurationMs = a.(int)
 		})
 	})
 
-	var sleepBetweenActionBatchesEnableRandomness bool
+	var sleepAfterActionBatchEnableRandomness bool
 	assignmentOps = append(assignmentOps, func() error {
-		return b.assigner.Assign(b.runnerKeyPath+".testLoop.batch.sleeps.betweenActionBatches.enableRandomness", client.ValidateBool, func(a any) {
-			sleepBetweenActionBatchesEnableRandomness = a.(bool)
+		return b.assigner.Assign(b.runnerKeyPath+".testLoop.batch.sleeps.afterActionBatch.enableRandomness", client.ValidateBool, func(a any) {
+			sleepAfterActionBatchEnableRandomness = a.(bool)
 		})
 	})
 
@@ -177,10 +177,10 @@ func populateBatchTestLoopConfig(b runnerConfigBuilder) (*batchTestLoopConfig, e
 			durationMs:       sleepAfterBatchActionDurationMs,
 			enableRandomness: sleepAfterBatchActionEnableRandomness,
 		},
-		sleepBetweenActionBatches: &sleepConfig{
-			enabled:          sleepBetweenActionBatchesEnabled,
-			durationMs:       sleepBetweenActionBatchesDurationMs,
-			enableRandomness: sleepBetweenActionBatchesEnableRandomness,
+		sleepAfterActionBatch: &sleepConfig{
+			enabled:          sleepAfterActionBatchEnabled,
+			durationMs:       sleepAfterActionBatchDurationMs,
+			enableRandomness: sleepAfterActionBatchEnableRandomness,
 		},
 	}, nil
 

--- a/maps/runner_test.go
+++ b/maps/runner_test.go
@@ -34,13 +34,13 @@ var (
 		testMapRunnerKeyPath + ".sleeps.betweenRuns.enableRandomness":                      true,
 	}
 	batchTestConfig = map[string]any{
-		testMapRunnerKeyPath + ".testLoop.type":                                               "batch",
-		testMapRunnerKeyPath + ".testLoop.batch.sleeps.afterBatchAction.enabled":              true,
-		testMapRunnerKeyPath + ".testLoop.batch.sleeps.afterBatchAction.durationMs":           50,
-		testMapRunnerKeyPath + ".testLoop.batch.sleeps.afterBatchAction.enableRandomness":     false,
-		testMapRunnerKeyPath + ".testLoop.batch.sleeps.betweenActionBatches.enabled":          true,
-		testMapRunnerKeyPath + ".testLoop.batch.sleeps.betweenActionBatches.durationMs":       2_000,
-		testMapRunnerKeyPath + ".testLoop.batch.sleeps.betweenActionBatches.enableRandomness": true,
+		testMapRunnerKeyPath + ".testLoop.type":                                           "batch",
+		testMapRunnerKeyPath + ".testLoop.batch.sleeps.afterBatchAction.enabled":          true,
+		testMapRunnerKeyPath + ".testLoop.batch.sleeps.afterBatchAction.durationMs":       50,
+		testMapRunnerKeyPath + ".testLoop.batch.sleeps.afterBatchAction.enableRandomness": false,
+		testMapRunnerKeyPath + ".testLoop.batch.sleeps.afterActionBatch.enabled":          true,
+		testMapRunnerKeyPath + ".testLoop.batch.sleeps.afterActionBatch.durationMs":       2_000,
+		testMapRunnerKeyPath + ".testLoop.batch.sleeps.afterActionBatch.enableRandomness": true,
 	}
 	boundaryTestConfig = map[string]any{
 		testMapRunnerKeyPath + ".testLoop.type":                                                    "boundary",
@@ -330,18 +330,18 @@ func configValuesAsExpected(rc *runnerConfig, expected map[string]any) (bool, st
 			return false, keyPath
 		}
 
-		keyPath = testMapRunnerKeyPath + ".testLoop.batch.sleeps.betweenActionBatches.enabled"
-		if rc.batch.sleepBetweenActionBatches.enabled != expected[keyPath] {
+		keyPath = testMapRunnerKeyPath + ".testLoop.batch.sleeps.afterActionBatch.enabled"
+		if rc.batch.sleepAfterActionBatch.enabled != expected[keyPath] {
 			return false, keyPath
 		}
 
-		keyPath = testMapRunnerKeyPath + ".testLoop.batch.sleeps.betweenActionBatches.durationMs"
-		if rc.batch.sleepBetweenActionBatches.durationMs != expected[keyPath] {
+		keyPath = testMapRunnerKeyPath + ".testLoop.batch.sleeps.afterActionBatch.durationMs"
+		if rc.batch.sleepAfterActionBatch.durationMs != expected[keyPath] {
 			return false, keyPath
 		}
 
-		keyPath = testMapRunnerKeyPath + ".testLoop.batch.sleeps.betweenActionBatches.enableRandomness"
-		if rc.batch.sleepBetweenActionBatches.enableRandomness != expected[keyPath] {
+		keyPath = testMapRunnerKeyPath + ".testLoop.batch.sleeps.afterActionBatch.enableRandomness"
+		if rc.batch.sleepAfterActionBatch.enableRandomness != expected[keyPath] {
 			return false, keyPath
 		}
 

--- a/maps/testloop.go
+++ b/maps/testloop.go
@@ -621,7 +621,7 @@ func insertInitialTestLoopStatus(g status.Gatherer, numMaps uint16, numRuns uint
 
 func (l *batchTestLoop[t]) runForMap(m hazelcastwrapper.Map, mapName string, mapNumber uint16) {
 
-	sleepBetweenActionBatchesConfig := l.tle.runnerConfig.batch.sleepBetweenActionBatches
+	sleepAfterActionBatchConfig := l.tle.runnerConfig.batch.sleepAfterActionBatch
 	sleepBetweenRunsConfig := l.tle.runnerConfig.sleepBetweenRuns
 
 	for i := uint32(0); i < l.tle.runnerConfig.numRuns; i++ {
@@ -635,13 +635,13 @@ func (l *batchTestLoop[t]) runForMap(m hazelcastwrapper.Map, mapName string, map
 			lp.LogHzEvent(fmt.Sprintf("failed to ingest data into map '%s' in run %d: %s", mapName, i, err), log.WarnLevel)
 			continue
 		}
-		l.s.sleep(sleepBetweenActionBatchesConfig, sleepTimeFunc, l.tle.runnerName)
+		l.s.sleep(sleepAfterActionBatchConfig, sleepTimeFunc, l.tle.runnerName)
 		err = l.readAll(m, mapName, mapNumber)
 		if err != nil {
 			lp.LogHzEvent(fmt.Sprintf("failed to read data from map '%s' in run %d: %s", mapName, i, err), log.WarnLevel)
 			continue
 		}
-		l.s.sleep(sleepBetweenActionBatchesConfig, sleepTimeFunc, l.tle.runnerName)
+		l.s.sleep(sleepAfterActionBatchConfig, sleepTimeFunc, l.tle.runnerName)
 		err = l.removeSome(m, mapName, mapNumber)
 		if err != nil {
 			lp.LogHzEvent(fmt.Sprintf("failed to delete data from map '%s' in run %d: %s", mapName, i, err), log.WarnLevel)

--- a/maps/testloop.go
+++ b/maps/testloop.go
@@ -647,6 +647,7 @@ func (l *batchTestLoop[t]) runForMap(m hazelcastwrapper.Map, mapName string, map
 			lp.LogHzEvent(fmt.Sprintf("failed to delete data from map '%s' in run %d: %s", mapName, i, err), log.WarnLevel)
 			continue
 		}
+		l.s.sleep(sleepAfterActionBatchConfig, sleepTimeFunc, l.tle.runnerName)
 	}
 
 	lp.LogMapRunnerEvent(fmt.Sprintf("map test loop done on map '%s' in map goroutine %d", mapName, mapNumber), l.tle.runnerName, log.InfoLevel)

--- a/maps/testloop_test.go
+++ b/maps/testloop_test.go
@@ -2955,7 +2955,7 @@ func TestRunWithBatchTestLoop(t *testing.T) {
 				defer resetGetOrAssemblePayloadTestSetup()
 
 				scBetweenRuns := &sleepConfig{}
-				scBetweenActionBatches := &sleepConfig{}
+				scAfterActionBatch := &sleepConfig{}
 				rc := assembleRunnerConfigForBatchTestLoop(
 					&runnerProperties{
 						numMaps:             1,
@@ -2964,17 +2964,17 @@ func TestRunWithBatchTestLoop(t *testing.T) {
 						sleepBetweenRuns:    scBetweenRuns,
 					},
 					sleepConfigDisabled,
-					scBetweenActionBatches,
+					scAfterActionBatch,
 				)
 				tl := assembleBatchTestLoop(uuid.New(), testSource, &testHzClientHandler{}, assembleTestMapStore(&testMapStoreBehavior{}), rc)
 
 				numInvocationsBetweenRuns := 0
-				numInvocationsBetweenActionBatches := 0
+				numInvocationsAfterActionBatch := 0
 				sleepTimeFunc = func(sc *sleepConfig) int {
 					if sc == scBetweenRuns {
 						numInvocationsBetweenRuns++
-					} else if sc == scBetweenActionBatches {
-						numInvocationsBetweenActionBatches++
+					} else if sc == scAfterActionBatch {
+						numInvocationsAfterActionBatch++
 					}
 					return 0
 				}
@@ -2989,7 +2989,7 @@ func TestRunWithBatchTestLoop(t *testing.T) {
 				}
 
 				msg = "\t\tnumber of sleeps between action batches must be zero"
-				if numInvocationsBetweenActionBatches == 0 {
+				if numInvocationsAfterActionBatch == 0 {
 					t.Log(msg, checkMark)
 				} else {
 					t.Fatal(msg, ballotX)
@@ -3018,12 +3018,12 @@ func TestRunWithBatchTestLoop(t *testing.T) {
 				tl := assembleBatchTestLoop(uuid.New(), testSource, &testHzClientHandler{}, assembleTestMapStore(&testMapStoreBehavior{}), rc)
 
 				numInvocationsBetweenRuns := uint32(0)
-				numInvocationsBetweenActionBatches := uint32(0)
+				numInvocationsAfterActionBatch := uint32(0)
 				sleepTimeFunc = func(sc *sleepConfig) int {
 					if sc == scBetweenRuns {
 						numInvocationsBetweenRuns++
 					} else if sc == scBetweenActionsBatches {
-						numInvocationsBetweenActionBatches++
+						numInvocationsAfterActionBatch++
 					}
 					return 0
 				}
@@ -3038,7 +3038,7 @@ func TestRunWithBatchTestLoop(t *testing.T) {
 				}
 
 				msg = "\t\tnumber of sleeps between action batches must be equal to two times the number of runs"
-				if numInvocationsBetweenActionBatches == 2*numRuns {
+				if numInvocationsAfterActionBatch == 2*numRuns {
 					t.Log(msg, checkMark)
 				} else {
 					t.Fatal(msg, ballotX)
@@ -3885,11 +3885,11 @@ func assembleRunnerConfigForBoundaryTestLoop(
 func assembleRunnerConfigForBatchTestLoop(
 	rp *runnerProperties,
 	sleepAfterChainAction *sleepConfig,
-	sleepBetweenActionBatches *sleepConfig,
+	sleepAfterActionBatch *sleepConfig,
 ) *runnerConfig {
 
 	c := assembleBaseRunnerConfig(rp)
-	c.batch = &batchTestLoopConfig{sleepAfterChainAction, sleepBetweenActionBatches}
+	c.batch = &batchTestLoopConfig{sleepAfterChainAction, sleepAfterActionBatch}
 
 	return c
 

--- a/maps/testloop_test.go
+++ b/maps/testloop_test.go
@@ -3037,8 +3037,8 @@ func TestRunWithBatchTestLoop(t *testing.T) {
 					t.Fatal(msg, ballotX)
 				}
 
-				msg = "\t\tnumber of sleeps between action batches must be equal to two times the number of runs"
-				if numInvocationsAfterActionBatch == 2*numRuns {
+				msg = "\t\tnumber of sleeps after action batch must three times the number of runs"
+				if numInvocationsAfterActionBatch == 3*numRuns {
 					t.Log(msg, checkMark)
 				} else {
 					t.Fatal(msg, ballotX)

--- a/queues/runner.go
+++ b/queues/runner.go
@@ -32,12 +32,12 @@ type (
 		pollConfig                  *operationConfig
 	}
 	operationConfig struct {
-		enabled                   bool
-		numRuns                   uint32
-		batchSize                 int
-		initialDelay              *sleepConfig
-		sleepBetweenActionBatches *sleepConfig
-		sleepBetweenRuns          *sleepConfig
+		enabled               bool
+		numRuns               uint32
+		batchSize             int
+		initialDelay          *sleepConfig
+		sleepAfterActionBatch *sleepConfig
+		sleepBetweenRuns      *sleepConfig
 	}
 	sleepConfig struct {
 		enabled          bool
@@ -196,7 +196,7 @@ func (b runnerConfigBuilder) populateOperationConfig(operation string) (*operati
 		return nil, err
 	}
 
-	sleepBetweenActionBatches, err := b.populateSleepConfig(c + ".sleeps.betweenActionBatches")
+	sleepAfterActionBatch, err := b.populateSleepConfig(c + ".sleeps.afterActionBatch")
 	if err != nil {
 		return nil, err
 	}
@@ -207,12 +207,12 @@ func (b runnerConfigBuilder) populateOperationConfig(operation string) (*operati
 	}
 
 	return &operationConfig{
-		enabled:                   enabled,
-		numRuns:                   numRuns,
-		batchSize:                 batchSizePoll,
-		initialDelay:              initialDelay,
-		sleepBetweenActionBatches: sleepBetweenActionBatches,
-		sleepBetweenRuns:          sleepBetweenRuns,
+		enabled:               enabled,
+		numRuns:               numRuns,
+		batchSize:             batchSizePoll,
+		initialDelay:          initialDelay,
+		sleepAfterActionBatch: sleepAfterActionBatch,
+		sleepBetweenRuns:      sleepBetweenRuns,
 	}, nil
 
 }

--- a/queues/runner_test.go
+++ b/queues/runner_test.go
@@ -11,36 +11,36 @@ import (
 
 var (
 	testConfig = map[string]any{
-		runnerKeyPath + ".enabled":                                                 true,
-		runnerKeyPath + ".numQueues":                                               5,
-		runnerKeyPath + ".appendQueueIndexToQueueName":                             true,
-		runnerKeyPath + ".appendClientIdToQueueName":                               false,
-		runnerKeyPath + ".queuePrefix.enabled":                                     true,
-		runnerKeyPath + ".queuePrefix.prefix":                                      queuePrefix,
-		runnerKeyPath + ".putConfig.enabled":                                       true,
-		runnerKeyPath + ".putConfig.numRuns":                                       500,
-		runnerKeyPath + ".putConfig.batchSize":                                     50,
-		runnerKeyPath + ".putConfig.sleeps.initialDelay.enabled":                   true,
-		runnerKeyPath + ".putConfig.sleeps.initialDelay.durationMs":                2000,
-		runnerKeyPath + ".putConfig.sleeps.initialDelay.enableRandomness":          true,
-		runnerKeyPath + ".putConfig.sleeps.betweenActionBatches.enabled":           true,
-		runnerKeyPath + ".putConfig.sleeps.betweenActionBatches.durationMs":        1000,
-		runnerKeyPath + ".putConfig.sleeps.betweenActionBatches.enableRandomness":  true,
-		runnerKeyPath + ".putConfig.sleeps.betweenRuns.enabled":                    true,
-		runnerKeyPath + ".putConfig.sleeps.betweenRuns.durationMs":                 2000,
-		runnerKeyPath + ".putConfig.sleeps.betweenRuns.enableRandomness":           true,
-		runnerKeyPath + ".pollConfig.enabled":                                      true,
-		runnerKeyPath + ".pollConfig.numRuns":                                      500,
-		runnerKeyPath + ".pollConfig.batchSize":                                    50,
-		runnerKeyPath + ".pollConfig.sleeps.initialDelay.enabled":                  true,
-		runnerKeyPath + ".pollConfig.sleeps.initialDelay.durationMs":               12500,
-		runnerKeyPath + ".pollConfig.sleeps.initialDelay.enableRandomness":         true,
-		runnerKeyPath + ".pollConfig.sleeps.betweenActionBatches.enabled":          true,
-		runnerKeyPath + ".pollConfig.sleeps.betweenActionBatches.durationMs":       1000,
-		runnerKeyPath + ".pollConfig.sleeps.betweenActionBatches.enableRandomness": true,
-		runnerKeyPath + ".pollConfig.sleeps.betweenRuns.enabled":                   true,
-		runnerKeyPath + ".pollConfig.sleeps.betweenRuns.durationMs":                2000,
-		runnerKeyPath + ".pollConfig.sleeps.betweenRuns.enableRandomness":          true,
+		runnerKeyPath + ".enabled":                                             true,
+		runnerKeyPath + ".numQueues":                                           5,
+		runnerKeyPath + ".appendQueueIndexToQueueName":                         true,
+		runnerKeyPath + ".appendClientIdToQueueName":                           false,
+		runnerKeyPath + ".queuePrefix.enabled":                                 true,
+		runnerKeyPath + ".queuePrefix.prefix":                                  queuePrefix,
+		runnerKeyPath + ".putConfig.enabled":                                   true,
+		runnerKeyPath + ".putConfig.numRuns":                                   500,
+		runnerKeyPath + ".putConfig.batchSize":                                 50,
+		runnerKeyPath + ".putConfig.sleeps.initialDelay.enabled":               true,
+		runnerKeyPath + ".putConfig.sleeps.initialDelay.durationMs":            2000,
+		runnerKeyPath + ".putConfig.sleeps.initialDelay.enableRandomness":      true,
+		runnerKeyPath + ".putConfig.sleeps.afterActionBatch.enabled":           true,
+		runnerKeyPath + ".putConfig.sleeps.afterActionBatch.durationMs":        1000,
+		runnerKeyPath + ".putConfig.sleeps.afterActionBatch.enableRandomness":  true,
+		runnerKeyPath + ".putConfig.sleeps.betweenRuns.enabled":                true,
+		runnerKeyPath + ".putConfig.sleeps.betweenRuns.durationMs":             2000,
+		runnerKeyPath + ".putConfig.sleeps.betweenRuns.enableRandomness":       true,
+		runnerKeyPath + ".pollConfig.enabled":                                  true,
+		runnerKeyPath + ".pollConfig.numRuns":                                  500,
+		runnerKeyPath + ".pollConfig.batchSize":                                50,
+		runnerKeyPath + ".pollConfig.sleeps.initialDelay.enabled":              true,
+		runnerKeyPath + ".pollConfig.sleeps.initialDelay.durationMs":           12500,
+		runnerKeyPath + ".pollConfig.sleeps.initialDelay.enableRandomness":     true,
+		runnerKeyPath + ".pollConfig.sleeps.afterActionBatch.enabled":          true,
+		runnerKeyPath + ".pollConfig.sleeps.afterActionBatch.durationMs":       1000,
+		runnerKeyPath + ".pollConfig.sleeps.afterActionBatch.enableRandomness": true,
+		runnerKeyPath + ".pollConfig.sleeps.betweenRuns.enabled":               true,
+		runnerKeyPath + ".pollConfig.sleeps.betweenRuns.durationMs":            2000,
+		runnerKeyPath + ".pollConfig.sleeps.betweenRuns.enableRandomness":      true,
 	}
 	initTestQueueStore initQueueStoreFunc = func(_ hazelcastwrapper.HzClientHandler) hazelcastwrapper.QueueStore {
 		return &testHzQueueStore{observations: &testQueueStoreObservations{}}
@@ -173,9 +173,9 @@ func configValuesAsExpected(rc *runnerConfig, expected map[string]any) bool {
 		rc.putConfig.initialDelay.enabled == expected[runnerKeyPath+".putConfig.sleeps.initialDelay.enabled"] &&
 		rc.putConfig.initialDelay.durationMs == expected[runnerKeyPath+".putConfig.sleeps.initialDelay.durationMs"] &&
 		rc.putConfig.initialDelay.enableRandomness == expected[runnerKeyPath+".putConfig.sleeps.initialDelay.enableRandomness"] &&
-		rc.putConfig.sleepBetweenActionBatches.enabled == expected[runnerKeyPath+".putConfig.sleeps.betweenActionBatches.enabled"] &&
-		rc.putConfig.sleepBetweenActionBatches.durationMs == expected[runnerKeyPath+".putConfig.sleeps.betweenActionBatches.durationMs"] &&
-		rc.putConfig.sleepBetweenActionBatches.enableRandomness == expected[runnerKeyPath+".putConfig.sleeps.betweenActionBatches.enableRandomness"] &&
+		rc.putConfig.sleepAfterActionBatch.enabled == expected[runnerKeyPath+".putConfig.sleeps.afterActionBatch.enabled"] &&
+		rc.putConfig.sleepAfterActionBatch.durationMs == expected[runnerKeyPath+".putConfig.sleeps.afterActionBatch.durationMs"] &&
+		rc.putConfig.sleepAfterActionBatch.enableRandomness == expected[runnerKeyPath+".putConfig.sleeps.afterActionBatch.enableRandomness"] &&
 		rc.putConfig.sleepBetweenRuns.enabled == expected[runnerKeyPath+".putConfig.sleeps.betweenRuns.enabled"] &&
 		rc.putConfig.sleepBetweenRuns.durationMs == expected[runnerKeyPath+".putConfig.sleeps.betweenRuns.durationMs"] &&
 		rc.putConfig.sleepBetweenRuns.enableRandomness == expected[runnerKeyPath+".putConfig.sleeps.betweenRuns.enableRandomness"] &&
@@ -185,9 +185,9 @@ func configValuesAsExpected(rc *runnerConfig, expected map[string]any) bool {
 		rc.pollConfig.initialDelay.enabled == expected[runnerKeyPath+".pollConfig.sleeps.initialDelay.enabled"] &&
 		rc.pollConfig.initialDelay.durationMs == expected[runnerKeyPath+".pollConfig.sleeps.initialDelay.durationMs"] &&
 		rc.pollConfig.initialDelay.enableRandomness == expected[runnerKeyPath+".pollConfig.sleeps.initialDelay.enableRandomness"] &&
-		rc.pollConfig.sleepBetweenActionBatches.enabled == expected[runnerKeyPath+".pollConfig.sleeps.betweenActionBatches.enabled"] &&
-		rc.pollConfig.sleepBetweenActionBatches.durationMs == expected[runnerKeyPath+".pollConfig.sleeps.betweenActionBatches.durationMs"] &&
-		rc.pollConfig.sleepBetweenActionBatches.enableRandomness == expected[runnerKeyPath+".pollConfig.sleeps.betweenActionBatches.enableRandomness"] &&
+		rc.pollConfig.sleepAfterActionBatch.enabled == expected[runnerKeyPath+".pollConfig.sleeps.afterActionBatch.enabled"] &&
+		rc.pollConfig.sleepAfterActionBatch.durationMs == expected[runnerKeyPath+".pollConfig.sleeps.afterActionBatch.durationMs"] &&
+		rc.pollConfig.sleepAfterActionBatch.enableRandomness == expected[runnerKeyPath+".pollConfig.sleeps.afterActionBatch.enableRandomness"] &&
 		rc.pollConfig.sleepBetweenRuns.enabled == expected[runnerKeyPath+".pollConfig.sleeps.betweenRuns.enabled"] &&
 		rc.pollConfig.sleepBetweenRuns.durationMs == expected[runnerKeyPath+".pollConfig.sleeps.betweenRuns.durationMs"] &&
 		rc.pollConfig.sleepBetweenRuns.enableRandomness == expected[runnerKeyPath+".pollConfig.sleeps.betweenRuns.enableRandomness"]

--- a/queues/testloop.go
+++ b/queues/testloop.go
@@ -250,7 +250,7 @@ func (l *testLoop[t]) putElements(q hazelcastwrapper.Queue, queueName string) {
 			}
 		}
 		if i > 0 && i%putConfig.batchSize == 0 {
-			l.s.sleep(putConfig.sleepBetweenActionBatches, sleepTimeFunc, "betweenActionBatches", queueName, l.tle.runnerName, "put")
+			l.s.sleep(putConfig.sleepAfterActionBatch, sleepTimeFunc, "afterActionBatch", queueName, l.tle.runnerName, "put")
 		}
 	}
 
@@ -272,7 +272,7 @@ func (l *testLoop[t]) pollElements(q hazelcastwrapper.Queue, queueName string) {
 			lp.LogQueueRunnerEvent(fmt.Sprintf("successfully retrieved value from queue '%s'", queueName), l.tle.runnerName, log.TraceLevel)
 		}
 		if i > 0 && i%pollConfig.batchSize == 0 {
-			l.s.sleep(pollConfig.sleepBetweenActionBatches, sleepTimeFunc, "betweenActionBatches", queueName, l.tle.runnerName, "poll")
+			l.s.sleep(pollConfig.sleepAfterActionBatch, sleepTimeFunc, "afterActionBatch", queueName, l.tle.runnerName, "poll")
 		}
 	}
 

--- a/queues/testloop_test.go
+++ b/queues/testloop_test.go
@@ -737,20 +737,20 @@ func assembleTestLoopConfig(id uuid.UUID, source string, qs hazelcastwrapper.Que
 func assembleRunnerConfig(enablePut bool, numRunsPut int, enablePoll bool, numRunsPoll int, sleepConfigBetweenRunsPut *sleepConfig, sleepConfigBetweenRunsPoll *sleepConfig) runnerConfig {
 
 	putConfig := operationConfig{
-		enabled:                   enablePut,
-		numRuns:                   uint32(numRunsPut),
-		batchSize:                 1,
-		initialDelay:              sleepConfigDisabled,
-		sleepBetweenActionBatches: sleepConfigDisabled,
-		sleepBetweenRuns:          sleepConfigBetweenRunsPut,
+		enabled:               enablePut,
+		numRuns:               uint32(numRunsPut),
+		batchSize:             1,
+		initialDelay:          sleepConfigDisabled,
+		sleepAfterActionBatch: sleepConfigDisabled,
+		sleepBetweenRuns:      sleepConfigBetweenRunsPut,
 	}
 	pollConfig := operationConfig{
-		enabled:                   enablePoll,
-		numRuns:                   uint32(numRunsPoll),
-		batchSize:                 1,
-		initialDelay:              sleepConfigDisabled,
-		sleepBetweenActionBatches: sleepConfigDisabled,
-		sleepBetweenRuns:          sleepConfigBetweenRunsPoll,
+		enabled:               enablePoll,
+		numRuns:               uint32(numRunsPoll),
+		batchSize:             1,
+		initialDelay:          sleepConfigDisabled,
+		sleepAfterActionBatch: sleepConfigDisabled,
+		sleepBetweenRuns:      sleepConfigBetweenRunsPoll,
 	}
 	return runnerConfig{
 		enabled:                     true,

--- a/resources/charts/hazeltest/Chart.yaml
+++ b/resources/charts/hazeltest/Chart.yaml
@@ -4,6 +4,6 @@ description: A Helm chart for deploying Hazeltest on Kubernetes
 
 type: application
 
-version: 1.3.1
+version: 1.3.2
 
-appVersion: "0.16.1"
+appVersion: "0.16.2"

--- a/resources/charts/hazeltest/values.yaml
+++ b/resources/charts/hazeltest/values.yaml
@@ -111,7 +111,7 @@ config:
             enabled: false
             durationMs: 2000
             enableRandomness: false
-          betweenActionBatches:
+          afterActionBatch:
             enabled: true
             durationMs: 2000
             enableRandomness: true
@@ -128,7 +128,7 @@ config:
             enabled: true
             durationMs: 2000
             enableRandomness: false
-          betweenActionBatches:
+          afterActionBatch:
             enabled: true
             durationMs: 2000
             enableRandomness: true
@@ -155,7 +155,7 @@ config:
             enabled: false
             durationMs: 2000
             enableRandomness: false
-          betweenActionBatches:
+          afterActionBatch:
             enabled: true
             durationMs: 1000
             enableRandomness: true
@@ -172,7 +172,7 @@ config:
             enabled: true
             durationMs: 2000
             enableRandomness: false
-          betweenActionBatches:
+          afterActionBatch:
             enabled: true
             durationMs: 1000
             enableRandomness: true
@@ -210,7 +210,7 @@ config:
               enabled: true
               durationMs: 50
               enableRandomness: true
-            betweenActionBatches:
+            afterActionBatch:
               enabled: true
               durationMs: 5000
               enableRandomness: true
@@ -278,7 +278,7 @@ config:
               enabled: true
               durationMs: 50
               enableRandomness: false
-            betweenActionBatches:
+            afterActionBatch:
               enabled: true
               durationMs: 2000
               enableRandomness: true

--- a/resources/charts/hazeltest/values.yaml
+++ b/resources/charts/hazeltest/values.yaml
@@ -4,8 +4,8 @@ image:
   registry: docker.io
   organization: antsinmyey3sjohnson
   repository: hazeltest
-  tag: 0.16.1
-  digest: 0e0aeaff9261b4c834c0a6f6141eae66b4488133a9de80f90ae651742435ddb9
+  tag: 0.16.2
+  digest: 4b843a1854de4e577a4bfdd6ce0972d3f0ad398f08e43313dae8aa3219bb5adf
   pullPolicy: IfNotPresent
 
 resources:


### PR DESCRIPTION
The map runners' batch test loop works in batches of operations, where one set of insert, read, and delete operations constitutes one run. Thus, the way to think about one run is a kind of logical "box" that separates sets of batches from other runs, or other boxes. 

In this context, the batch test loop's `sleeps.betweenActionBatches` property was confusing: Inserting a sleep after the remove batch in run _n_ violates the logical box of run _n_, as the term "between" implies a connection to the "other side" of that "between", being the insert batch of run _n+1_. Thus, at the time of implementing the first iteration of this feature a long time ago, it was decided that there should be no sleep after the remove batch.

This PR clears up the confusion around `sleeps.betweenActionBatches` by renaming it to `sleeps.afterActionBatch` (not only in the context of the map runners' batch test loop, but also for queue runners in order to maintain consistency). With the confusion removed and the "box" of a batch test loop's run still in place if a sleep is inserted after the remove batch, this very sleep was added. Thus, if so configured -- by configuring `sleeps.afterActionBatche.enabled: true` --, the batch test loop will now sleep three times during one run, once after each batch of operations.

The corresponding configuration of the batch test loop now looks like the following (excerpt from the map `PokedexRunner`):

```yaml
mapTests:
  pokedex:
      # ...
      batch:
        sleeps:
          # ...
          # Mind the difference between 'afterBatchAction' (this property) and 'afterActionBatch' (the property
          # below) -- whereas the former refers to what happens after a single action within a batch of actions, the
          # latter is concerned with what happens after that batch of actions has concluded.
          afterBatchAction:
            enabled: true
            durationMs: 50
            enableRandomness: true
          # Can be enabled to make the batch test loop sleep for the given duration after one batch of actions (e.g.,
          # "ingest x elements") has finished, meaning the next action batch will start only after a sleep of <durationMs>
          afterActionBatch:
            enabled: true
            durationMs: 5000
            enableRandomness: true
      # ...
```

All traces of `sleeps.betweenActionBatches` have been replaced by `sleeps.afterActionBatch` in both the application's `defaultConfig.yaml` file and the Helm chart's `values.yaml`, and corresponding source code was updated.

Closes #87.