### PR TITLE
Rework Payload Generation Mechanism To Avoid Unnecessary Memory Usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,25 @@
 # Hazeltest
-Welcome, fellow Hazelcast warrior! If you're looking at this code repository, it may be so because you've been facing the challenge of testing your Hazelcast clusters, and maybe you've been wondering if there are tools out there making that process a bit easier.
 
-Hazeltest is an application that attempts to achieve just that: By means of simple-to-configure, yet effective and versatile test loops, it stresses a Hazelcast cluster, thus facilitating the discovery of misconfigurations or other errors.
+Welcome, fellow Hazelcast warrior! If you're looking at this code repository, it may be so because you've been facing
+the challenge of testing your Hazelcast clusters, and maybe you've been wondering if there are tools out there making
+that process a bit easier.
 
-Right now, the application is still in a very early phase of development, but because I'm using it as a real-world project for learning Golang -- and because I actually do face the challenge of testing Hazelcast clusters in a project I currently work in --, you can expect more features to be added in the upcoming weeks.
+Hazeltest is an application that attempts to achieve just that: By means of simple-to-configure, yet effective and
+versatile test loops, it stresses a Hazelcast cluster, thus facilitating the discovery of misconfigurations or other
+errors.
 
-For a general overview of the background and ideas behind Hazeltest, please refer to the introductory blog post I've written, which you can find [here](https://nicokrieg.com/hazeltest-introduction.html).
+Right now, the application is still in a very early phase of development, but because I'm using it as a real-world
+project for learning Golang -- and because I actually do face the challenge of testing Hazelcast clusters in a project I
+currently work in --, you can expect more features to be added in the upcoming weeks.
+
+For a general overview of the background and ideas behind Hazeltest, please refer to the introductory blog post I've
+written, which you can find [here](https://nicokrieg.com/hazeltest-introduction.html).
 
 ## Getting Started
-Have a Kubernetes cluster at your disposal? Then you're in luck, because the easiest and most convenient way to get started is to apply the two Helm charts you can find in this repository's [chart](./resources/charts/) folder to it. First, get yourself a neat little Hazelcast cluster by running the following:
+
+Have a Kubernetes cluster at your disposal? Then you're in luck, because the easiest and most convenient way to get
+started is to apply the two Helm charts you can find in this repository's [chart](./resources/charts/) folder to it.
+First, get yourself a neat little Hazelcast cluster by running the following:
 
 ```bash
 helm upgrade --install hazelcastwithmancenter ./hazelcastwithmancenter --namespace=hazelcastplatform --create-namespace
@@ -20,52 +31,95 @@ Once the cluster is up and running, you can install Hazeltest like so:
 helm upgrade --install hazeltest ./hazeltest --namespace=hazelcastplatform
 ```
 
-In the Hazeltest pod, you should see some logging statements informing about the duration of a bunch of `getMap()` calls the two runners enabled by default have made on the Hazelcast cluster.
+In the Hazeltest pod, you should see some logging statements informing about the duration of a bunch of `getMap()` calls
+the two runners enabled by default have made on the Hazelcast cluster.
 
 ## Diving Deeper
-The next step you may be inclined to do is to take a closer look at which test runners are currently available in the application and how they can be configured.
+
+The next step you may be inclined to do is to take a closer look at which test runners are currently available in the
+application and how they can be configured.
 
 ### Available Runners
-The first runner available today is the `PokedexRunner`, which runs the test loop with the 151 Pokémon of the first-generation Pokédex. It serializes them into a string-based Json structure, which is then saved to Hazelcast. The `PokedexRunner` is not intended to put a lot of data into Hazelcast (i. e., it is not intended to load-test a Hazelcast cluster in terms of its memory), but instead stresses the CPU. The second available runner, on the other hand, is the `LoadRunner`, and as its name indicates, it is designed to "load up" the Hazelcast cluster under test with lots of data such as to test the behavior of the cluster once its maximum storage capacity has been reached. As opposed to the `PokedexRunner`, which is -- by nature of the data it works with -- restricted to 151 elements in each map, the `LoadRunner` can be configured arbitrarily regarding the number of elements it should put into each map, and the elements' size is configurable, too. 
+
+The first runner available today is the `PokedexRunner`, which runs the test loop with the 151 Pokémon of the
+first-generation Pokédex. It serializes them into a string-based Json structure, which is then saved to Hazelcast.
+The `PokedexRunner` is not intended to put a lot of data into Hazelcast (i. e., it is not intended to load-test a
+Hazelcast cluster in terms of its memory), but instead stresses the CPU. The second available runner, on the other hand,
+is the `LoadRunner`, and as its name indicates, it is designed to "load up" the Hazelcast cluster under test with lots
+of data such as to test the behavior of the cluster once its maximum storage capacity has been reached. As opposed to
+the `PokedexRunner`, which is -- by nature of the data it works with -- restricted to 151 elements in each map,
+the `LoadRunner` can be configured arbitrarily regarding the number of elements it should put into each map, and the
+elements' size is configurable, too.
 
 ### Configuration
-The default configuration resides right with the source code, and you can find it [here](./client/defaultConfig.yaml). It contains all properties currently available for configuring the two aforementioned runners along with comments shortly describing what each property does and what it can be used for.
 
-You can find all properties for configuring the Hazeltest application itself in the [`values.yaml`](./resources/charts/hazeltest/values.yaml) file of the [Hazeltest Helm chart](./resources/charts/hazeltest/) along with comments explaining them.
+The default configuration resides right with the source code, and you can find it [here](./client/defaultConfig.yaml).
+It contains all properties currently available for configuring the two aforementioned runners along with comments
+shortly describing what each property does and what it can be used for.
+
+You can find all properties for configuring the Hazeltest application itself in
+the [`values.yaml`](./resources/charts/hazeltest/values.yaml) file of
+the [Hazeltest Helm chart](./resources/charts/hazeltest/) along with comments explaining them.
 
 ## Monitoring Your Hazelcast Cluster
-Once you deployed Hazeltest so it generates some load on your Hazelcast cluster under test, you might want to start monitoring it in order to get a more thorough understanding for the sort of load Hazeltest creates and how your cluster's members can deal with that load. In case you have deployed Hazelcast to a Kubernetes cluster, you may find the small monitoring stack this repository offers useful. In short, it utilizes the following components:
+
+Once you deployed Hazeltest so it generates some load on your Hazelcast cluster under test, you might want to start
+monitoring it in order to get a more thorough understanding for the sort of load Hazeltest creates and how your
+cluster's members can deal with that load. In case you have deployed Hazelcast to a Kubernetes cluster, you may find the
+small monitoring stack this repository offers useful. In short, it utilizes the following components:
 
 * Prometheus for scraping the Pods of your Hazelcast cluster (or clusters)
-* Grafana dashboards for visualizing the metrics scraped by Prometheus 
+* Grafana dashboards for visualizing the metrics scraped by Prometheus
 * Grafana itself
 
-The latter two are provided by the [`padogrid-hazelmon`](https://hub.docker.com/r/antsinmyey3sjohnson/padogrid-hazelmon) image, which itself is based on a [`padogrid`](https://hub.docker.com/r/padogrid/padogrid) image. (In case you're wondering what PadoGrid is and how it can help you, there's a short introduction down below.)
+The latter two are provided by the [`padogrid-hazelmon`](https://hub.docker.com/r/antsinmyey3sjohnson/padogrid-hazelmon)
+image, which itself is based on a [`padogrid`](https://hub.docker.com/r/padogrid/padogrid) image. (In case you're
+wondering what PadoGrid is and how it can help you, there's a short introduction down below.)
 
 ### Installing Hazelcast
-To make the monitoring stack work, both the Community and Enterprise edition of Hazelcast will do fine, as both offer the _com_hazelcast_ metrics the Grafana dashboards rely on. In case you would still like to use the Enterprise version using the chart provided in this repository, check out the [_Installing Hazelcast Enterprise_](#installing-hazelcast-enterprise) section down below.
 
-You can deploy the Hazelcast cluster to be monitored using the same old Helm command you may have already encountered in the [_Getting Started_](#getting-started) section above (assuming you're in the [`resources/charts`](./resources/charts/) directory of your local copy of this repository):
+To make the monitoring stack work, both the Community and Enterprise edition of Hazelcast will do fine, as both offer
+the _com_hazelcast_ metrics the Grafana dashboards rely on. In case you would still like to use the Enterprise version
+using the chart provided in this repository, check out the [_Installing Hazelcast
+Enterprise_](#installing-hazelcast-enterprise) section down below.
+
+You can deploy the Hazelcast cluster to be monitored using the same old Helm command you may have already encountered in
+the [_Getting Started_](#getting-started) section above (assuming you're in
+the [`resources/charts`](./resources/charts/) directory of your local copy of this repository):
 
 ```bash
 helm upgrade --install hazelcastwithmancenter ./hazelcastwithmancenter --namespace=hazelcastplatform --create-namespace
 ```
 
 ### Installing Prometheus
-Once your Hazelcast cluster is up and running, it's time to scrape some metrics! To do so, you can install Prometheus using the following command:
+
+Once your Hazelcast cluster is up and running, it's time to scrape some metrics! To do so, you can install Prometheus
+using the following command:
 
 ```bash
 helm upgrade --install prometheus ./prometheus --namespace prometheus --create-namespace
 ```
 
-(You can modify the Prometheus configuration in the chart's [`values.yaml`](./resources/charts/prometheus/values.yaml) file if you so desire, of course, but the properties already provided there should work out of the box.)
+(You can modify the Prometheus configuration in the chart's [`values.yaml`](./resources/charts/prometheus/values.yaml)
+file if you so desire, of course, but the properties already provided there should work out of the box.)
 
-You can check whether the _com_hazelcast_ metrics are scraped correctly by navigating to Prometheus' web UI. The URL for doing so corresponds to the following pattern: `http://<external ip of prometheus loadbalancer service>:9090`
+You can check whether the _com_hazelcast_ metrics are scraped correctly by navigating to Prometheus' web UI. The URL for
+doing so corresponds to the following pattern: `http://<external ip of prometheus loadbalancer service>:9090`
 
 ### Installing `padogrid-hazelmon`
-The last puzzle piece in this small monitoring stack is the [`padogrid-hazelmon`](https://hub.docker.com/r/antsinmyey3sjohnson/padogrid-hazelmon) image that comes bundled both with Grafana and some really sweet dashboards for monitoring Hazelcast (more precisely speaking, the image's base image, [`padogrid`](https://hub.docker.com/r/padogrid/padogrid), offers all the dashboards, and `padogrid-hazelmon` merely adds Grafana and performs some work to get Grafana configured and running when deployed in a Helm chart). 
 
-The `padogrid-hazelmon` installation must be pointed to the Prometheus server that scrapes the _com_hazelcast_ metrics from your Hazelcast cluster's members. In case you installed Prometheus according to the instructions above without having modified the chart, the `padogridwithgrafana` chart will work out of the box, too. In case you have modified either the name of the Kubernetes Service that points to your Prometheus Pod, the namespace, or the port, please make sure to adjust the `PADO_MONITORING_PROMETHEUS_URL` property beneath the `padogridWithGrafana.config.padoEnv` object in the chart's [`values.yaml`](./resources/charts/padogridwithgrafana/values.yaml) file accordingly.
+The last puzzle piece in this small monitoring stack is
+the [`padogrid-hazelmon`](https://hub.docker.com/r/antsinmyey3sjohnson/padogrid-hazelmon) image that comes bundled both
+with Grafana and some really sweet dashboards for monitoring Hazelcast (more precisely speaking, the image's base
+image, [`padogrid`](https://hub.docker.com/r/padogrid/padogrid), offers all the dashboards, and `padogrid-hazelmon`
+merely adds Grafana and performs some work to get Grafana configured and running when deployed in a Helm chart).
+
+The `padogrid-hazelmon` installation must be pointed to the Prometheus server that scrapes the _com_hazelcast_ metrics
+from your Hazelcast cluster's members. In case you installed Prometheus according to the instructions above without
+having modified the chart, the `padogridwithgrafana` chart will work out of the box, too. In case you have modified
+either the name of the Kubernetes Service that points to your Prometheus Pod, the namespace, or the port, please make
+sure to adjust the `PADO_MONITORING_PROMETHEUS_URL` property beneath the `padogridWithGrafana.config.padoEnv` object in
+the chart's [`values.yaml`](./resources/charts/padogridwithgrafana/values.yaml) file accordingly.
 
 You can install the chart like so:
 
@@ -74,37 +128,54 @@ helm upgrade --install padogridwithgrafana ./padogridwithgrafana --namespace haz
 ```
 
 ### Harvesting The Fruits
-Finally, you'll probably want to get some monitoring done using this freshly installed monitoring stack. To do so, visit the Grafana web UI and navigate to the _Dashboards_ page:
+
+Finally, you'll probably want to get some monitoring done using this freshly installed monitoring stack. To do so, visit
+the Grafana web UI and navigate to the _Dashboards_ page:
 
 ```
 http://<external ip for grafana loadbalancer service>:3000/dashboards
 ```
 
-> :warning: **Note:** If this is your first login to Grafana, you can log in using Grafana's default username/password combination, which, at the time of this writing, is _admin/admin_. Of course, it is recommended to change this to something more secure once Grafana prompts you to do so.
+> :warning: **Note:** If this is your first login to Grafana, you can log in using Grafana's default username/password
+> combination, which, at the time of this writing, is _admin/admin_. Of course, it is recommended to change this to
+> something more secure once Grafana prompts you to do so.
 
 Here, the available dashboards are categorized into multiple folders:
 
 ![Overview of dashboards available in Grafana](./resources/images_for_readme/grafana_dashboards_overview.png)
 
-A good place to start is the _00Main_ dashboard in the _Hazelcast_ folder. Wih a very small Hazelcast cluster, it might look something like the following:
+A good place to start is the _00Main_ dashboard in the _Hazelcast_ folder. Wih a very small Hazelcast cluster, it might
+look something like the following:
 
 ![Dashboard showing an overview of the state of a small Hazelcast cluster.](./resources/images_for_readme/grafana_dashboard_hazelcast_00main.png)
 
-This should give you a good overview of how your Hazelcast cluster is currently doing, and more detailed views are available via the links on the left-hand side of the dashboard. In fact, there is quite a lot to discover, so feel free to dig in and have fun exploring!
+This should give you a good overview of how your Hazelcast cluster is currently doing, and more detailed views are
+available via the links on the left-hand side of the dashboard. In fact, there is quite a lot to discover, so feel free
+to dig in and have fun exploring!
 
 ## Installing Hazelcast Enterprise
-In case you would like to install Hazelcast in the Enterprise edition using the chart offered in this repository, you may find the following notes useful.
 
-The [Helm chart](./resources/charts/hazelcastwithmancenter/) included in this repository for installing Hazelcast can be configured to use Hazelcast Enterprise rather than the community edition. The following properties in the [`values.yaml`](./resources/charts/hazelcastwithmancenter/values.yaml) file are important in this context:
+In case you would like to install Hazelcast in the Enterprise edition using the chart offered in this repository, you
+may find the following notes useful.
 
-* `.Values.platform.cluster.members.edition.enterprise.enable`: Whether to enable using the Enterprise edition. If set so `true`, the chart expects a Kubernetes Secret that contains the enterprise license key, see below.
+The [Helm chart](./resources/charts/hazelcastwithmancenter/) included in this repository for installing Hazelcast can be
+configured to use Hazelcast Enterprise rather than the community edition. The following properties in
+the [`values.yaml`](./resources/charts/hazelcastwithmancenter/values.yaml) file are important in this context:
+
+* `.Values.platform.cluster.members.edition.enterprise.enabled`: Whether to enable using the Enterprise edition. If set
+  so `true`, the chart expects a Kubernetes Secret that contains the enterprise license key, see below.
 * `.Values.platform.cluster.members.edition.enterprise.image`: The Hazelcast Enterprise image to use.
-* `.Values.platform.cluster.members.edition.enterprise.license.secretName`: The name of the Kubernetes Secret that contains the enterprise license key.
-* `.Values.platform.cluster.members.edition.enterprise.license.keyPath`: The path, within the secret, to the key that holds the enterprise license key as a string.
+* `.Values.platform.cluster.members.edition.enterprise.license.secretName`: The name of the Kubernetes Secret that
+  contains the enterprise license key.
+* `.Values.platform.cluster.members.edition.enterprise.license.keyPath`: The path, within the secret, to the key that
+  holds the enterprise license key as a string.
 
-> :warning: **Note:** The Hazelcast Enterprise cluster must be deployed to the same namespace that holds the Secret containing the license key.
+> :warning: **Note:** The Hazelcast Enterprise cluster must be deployed to the same namespace that holds the Secret
+> containing the license key.
 
-For example, assuming you would like to use the image for Hazelcast Enterprise 5.3.6 and your license key sits in a Secret called `hazelcast-enterprise-license` that represents the license key string a in a property called `data.licenseKey`, you would configure the properties above like so:
+For example, assuming you would like to use the image for Hazelcast Enterprise 5.3.6 and your license key sits in a
+Secret called `hazelcast-enterprise-license` that represents the license key string a in a property
+called `data.licenseKey`, you would configure the properties above like so:
 
 ```yaml
 platform:
@@ -129,11 +200,23 @@ helm upgrade --install hazelcastwithmancenter ./hazelcastwithmancenter --namespa
 ```
 
 ## Generating Load With PadoGrid
-_PadoGrid_ is an open source application that provides a fantastic playing ground for testing all kinds of data grid and computing technologies (Hazelcast is one of them, but since it's based on what the developer calls _distributed workspaces_ and pluggable _bundles_, it also works with other technologies like Spark, Kafka, and Hadoop). 
 
-There are different sub-programs available in PadoGrid, one of which is the [_perf_test_ application for Hazelcast](https://github.com/padogrid/padogrid/wiki/Hazelcast-perf_test-App). This handy tool offers the capability of running tests that can be configured by means of text-based properties files that describe the groups and operations to run in scope of a test. If your goal is to load-test your Hazelcast cluster in terms of memory and CPU only (rather than CPU and memory plus the number of maps and clients), then PadoGrid will perfectly suit your needs. 
+_PadoGrid_ is an open source application that provides a fantastic playing ground for testing all kinds of data grid and
+computing technologies (Hazelcast is one of them, but since it's based on what the developer calls _distributed
+workspaces_ and pluggable _bundles_, it also works with other technologies like Spark, Kafka, and Hadoop).
 
-On top of that, the most recent versions of PadoGrid (starting with v0.9.30) also contain super useful dashboards for monitoring Hazelcast clusters, and the `padogrid-hazelmon` image you may have encountered if you set up Hazeltest's monitoring stack according to the instructions above leverages them in a running Grafana instance you can access and use without much prior configuration work.
+There are different sub-programs available in PadoGrid, one of which is the [
+_perf_test_ application for Hazelcast](https://github.com/padogrid/padogrid/wiki/Hazelcast-perf_test-App). This handy
+tool offers the capability of running tests that can be configured by means of text-based properties files that describe
+the groups and operations to run in scope of a test. If your goal is to load-test your Hazelcast cluster in terms of
+memory and CPU only (rather than CPU and memory plus the number of maps and clients), then PadoGrid will perfectly suit
+your needs.
 
-You can find PadoGrid's source code and many useful guides for getting started over on [GitHub](https://github.com/padogrid/padogrid).
+On top of that, the most recent versions of PadoGrid (starting with v0.9.30) also contain super useful dashboards for
+monitoring Hazelcast clusters, and the `padogrid-hazelmon` image you may have encountered if you set up Hazeltest's
+monitoring stack according to the instructions above leverages them in a running Grafana instance you can access and use
+without much prior configuration work.
+
+You can find PadoGrid's source code and many useful guides for getting started over
+on [GitHub](https://github.com/padogrid/padogrid).
 

--- a/loadsupport/payloadgenerator.go
+++ b/loadsupport/payloadgenerator.go
@@ -53,7 +53,6 @@ const (
 
 var (
 	lp                     = logging.GetLogProviderInstance(client.ID())
-	DefaultProvider        = DefaultPayloadProvider{}
 	payloadConsumingActors sync.Map
 	fixedSizePayloads      sync.Map
 )
@@ -82,7 +81,7 @@ func (p *DefaultPayloadProvider) RetrievePayload(actorName string) (*string, err
 	}
 
 	if r.UseVariableSize {
-		return generateTrackedRandomStringPayloadWithinBoundary(actorName, r)
+		return generateRandomStringPayloadWithinBoundary(actorName, r)
 	} else {
 		return initializeAndReturnFixedSizePayload(actorName, r)
 	}
@@ -159,7 +158,7 @@ func initializeAndReturnFixedSizePayload(actorName string, r PayloadGenerationRe
 
 }
 
-func generateTrackedRandomStringPayloadWithinBoundary(actorName string, r PayloadGenerationRequirement) (*string, error) {
+func generateRandomStringPayloadWithinBoundary(actorName string, r PayloadGenerationRequirement) (*string, error) {
 
 	freshlyInserted := false
 	if _, ok := payloadConsumingActors.Load(actorName); !ok {

--- a/loadsupport/payloadgenerator.go
+++ b/loadsupport/payloadgenerator.go
@@ -66,6 +66,8 @@ func (p *DefaultPayloadProvider) RegisterPayloadGenerationRequirement(actorBaseN
 
 func (p *DefaultPayloadProvider) RetrievePayload(actorName string) (*string, error) {
 
+	lp.LogPayloadGeneratorEvent(fmt.Sprintf("retrieving payload for actor '%s'", actorName), log.TraceLevel)
+
 	r, err := p.findMatchingPayloadGenerationRequirement(actorName)
 
 	if err != nil {
@@ -119,6 +121,8 @@ func (p *DefaultPayloadProvider) findMatchingPayloadGenerationRequirement(actorN
 // May I just add that StackOverflow is such a highly fascinating place.
 func GenerateRandomStringPayload(n int) *string {
 
+	lp.LogPayloadGeneratorEvent(fmt.Sprintf("generating random string payload having size of %d byte/-s", n), log.TraceLevel)
+
 	src := rand.NewSource(time.Now().UnixNano())
 
 	b := make([]byte, n)
@@ -142,7 +146,7 @@ func GenerateRandomStringPayload(n int) *string {
 
 func initializeAndReturnFixedSizePayload(actorName string, r PayloadGenerationRequirement) (*string, error) {
 
-	lp.LogPayloadGeneratorEvent(fmt.Sprintf("retrieving fixed-size payload for actor '%s'", actorName), log.TraceLevel)
+	lp.LogPayloadGeneratorEvent(fmt.Sprintf("initializing fixed-size payload for actor '%s'", actorName), log.TraceLevel)
 
 	sizeBytes := r.FixedSize.SizeBytes
 	if _, ok := fixedSizePayloads.Load(r.FixedSize.SizeBytes); !ok {
@@ -159,6 +163,8 @@ func initializeAndReturnFixedSizePayload(actorName string, r PayloadGenerationRe
 }
 
 func generateRandomStringPayloadWithinBoundary(actorName string, r PayloadGenerationRequirement) (*string, error) {
+
+	lp.LogPayloadGeneratorEvent(fmt.Sprintf("generating random string payload for actor '%s' according to payload generation requirement: %v", actorName, r), log.TraceLevel)
 
 	freshlyInserted := false
 	if _, ok := payloadConsumingActors.Load(actorName); !ok {

--- a/loadsupport/payloadgenerator.go
+++ b/loadsupport/payloadgenerator.go
@@ -31,15 +31,9 @@ type (
 	VariableSizePayloadDefinition struct {
 		LowerBoundaryBytes, UpperBoundaryBytes, SameSizeStepsLimit int
 	}
-	VariablePayloadGenerationInfo struct {
+	variablePayloadGenerationInfo struct {
 		numGeneratePayloadInvocations int
 		payloadSize                   int
-	}
-)
-
-type (
-	FixedPayloadGenerationRequirement struct {
-		SizeBytes int
 	}
 )
 
@@ -170,13 +164,13 @@ func generateRandomStringPayloadWithinBoundary(actorName string, r PayloadGenera
 	if _, ok := payloadConsumingActors.Load(actorName); !ok {
 		freshlyInserted = true
 		lp.LogPayloadGeneratorEvent(fmt.Sprintf("creating new payload generation info for actor '%s'", actorName), log.InfoLevel)
-		payloadConsumingActors.Store(actorName, VariablePayloadGenerationInfo{})
+		payloadConsumingActors.Store(actorName, variablePayloadGenerationInfo{})
 	}
 
 	lp.LogPayloadGeneratorEvent(fmt.Sprintf("loading payload generation info for actor '%s'", actorName), log.TraceLevel)
 	v, _ := payloadConsumingActors.Load(actorName)
 
-	info := v.(VariablePayloadGenerationInfo)
+	info := v.(variablePayloadGenerationInfo)
 
 	steps, lower, upper := r.VariableSize.SameSizeStepsLimit, r.VariableSize.LowerBoundaryBytes, r.VariableSize.UpperBoundaryBytes
 	if info.numGeneratePayloadInvocations >= steps || freshlyInserted {

--- a/loadsupport/payloadgenerator.go
+++ b/loadsupport/payloadgenerator.go
@@ -47,14 +47,14 @@ func RegisterPayloadGenerationRequirement(actorBaseName string, r PayloadGenerat
 
 }
 
-func GenerateTrackedRandomStringPayloadWithinBoundary(actorName string) (string, error) {
+func GenerateTrackedRandomStringPayloadWithinBoundary(actorName string) (*string, error) {
 
 	lp.LogPayloadGeneratorEvent(fmt.Sprintf("generating payload for actor '%s'", actorName), log.TraceLevel)
 	r, err := ActorTracker.FindMatchingPayloadGenerationRequirement(actorName)
 
 	if err != nil {
 		lp.LogPayloadGeneratorEvent(fmt.Sprintf("cannot generate payload for actor '%s' because attempt to identify payload generation requirement resulted in error: %v", actorName, err), log.ErrorLevel)
-		return "", err
+		return nil, err
 	}
 
 	freshlyInserted := false
@@ -89,7 +89,7 @@ func GenerateTrackedRandomStringPayloadWithinBoundary(actorName string) (string,
 // GenerateRandomStringPayload generates a random string payload having a size of n bytes.
 // Copied from: https://stackoverflow.com/a/31832326
 // May I just add that StackOverflow is such a highly fascinating place.
-func GenerateRandomStringPayload(n int) string {
+func GenerateRandomStringPayload(n int) *string {
 
 	src := rand.NewSource(time.Now().UnixNano())
 
@@ -107,7 +107,8 @@ func GenerateRandomStringPayload(n int) string {
 		remain--
 	}
 
-	return string(b)
+	s := string(b)
+	return &s
 
 }
 

--- a/loadsupport/payloadgenerator.go
+++ b/loadsupport/payloadgenerator.go
@@ -53,7 +53,7 @@ var (
 
 func (p *DefaultPayloadProvider) RegisterPayloadGenerationRequirement(actorBaseName string, r PayloadGenerationRequirement) {
 
-	lp.LogPayloadGeneratorEvent(fmt.Sprintf("registering variable payload generation requirement for actor '%s': %v", actorBaseName, r), log.TraceLevel)
+	lp.LogPayloadGeneratorEvent(fmt.Sprintf("registering variable payload generation requirement for actor with base name '%s': %v", actorBaseName, r), log.TraceLevel)
 	p.actorRequirements.Store(actorBaseName, r)
 
 }

--- a/loadsupport/payloadgenerator.go
+++ b/loadsupport/payloadgenerator.go
@@ -13,7 +13,7 @@ import (
 )
 
 type (
-	PayloadConsumingActorTracker struct {
+	VariablePayloadConsumingActorTracker struct {
 		actors sync.Map
 	}
 	VariablePayloadGenerationRequirement struct {
@@ -24,6 +24,9 @@ type (
 		numGeneratePayloadInvocations int
 		payloadSize                   int
 	}
+)
+
+type (
 	FixedPayloadGenerationRequirement struct {
 		SizeBytes int
 	}
@@ -39,7 +42,7 @@ const (
 
 var (
 	lp                     = logging.GetLogProviderInstance(client.ID())
-	ActorTracker           = PayloadConsumingActorTracker{}
+	ActorTracker           = VariablePayloadConsumingActorTracker{}
 	payloadConsumingActors sync.Map
 	fixedPayloads          sync.Map
 )
@@ -152,7 +155,7 @@ func GenerateRandomStringPayload(n int) *string {
 
 }
 
-func (tr *PayloadConsumingActorTracker) FindMatchingPayloadGenerationRequirement(actorName string) (VariablePayloadGenerationRequirement, error) {
+func (tr *VariablePayloadConsumingActorTracker) FindMatchingPayloadGenerationRequirement(actorName string) (VariablePayloadGenerationRequirement, error) {
 
 	lp.LogPayloadGeneratorEvent(fmt.Sprintf("attempting to find previously registered payload generation requirement for actor '%s'", actorName), log.TraceLevel)
 

--- a/loadsupport/payloadgenerator.go
+++ b/loadsupport/payloadgenerator.go
@@ -93,7 +93,7 @@ func RegisterVariablePayloadGenerationRequirement(actorBaseName string, r Variab
 func GenerateTrackedRandomStringPayloadWithinBoundary(actorName string) (*string, error) {
 
 	lp.LogPayloadGeneratorEvent(fmt.Sprintf("generating payload for actor '%s'", actorName), log.TraceLevel)
-	r, err := ActorTracker.FindMatchingPayloadGenerationRequirement(actorName)
+	r, err := ActorTracker.FindMatchingVariableSizePayloadGenerationRequirement(actorName)
 
 	if err != nil {
 		lp.LogPayloadGeneratorEvent(fmt.Sprintf("cannot generate payload for actor '%s' because attempt to identify payload generation requirement resulted in error: %v", actorName, err), log.ErrorLevel)
@@ -155,7 +155,7 @@ func GenerateRandomStringPayload(n int) *string {
 
 }
 
-func (tr *VariablePayloadConsumingActorTracker) FindMatchingPayloadGenerationRequirement(actorName string) (VariablePayloadGenerationRequirement, error) {
+func (tr *VariablePayloadConsumingActorTracker) FindMatchingVariableSizePayloadGenerationRequirement(actorName string) (VariablePayloadGenerationRequirement, error) {
 
 	lp.LogPayloadGeneratorEvent(fmt.Sprintf("attempting to find previously registered payload generation requirement for actor '%s'", actorName), log.TraceLevel)
 

--- a/loadsupport/payloadgenerator_test.go
+++ b/loadsupport/payloadgenerator_test.go
@@ -1,6 +1,7 @@
 package loadsupport
 
 import (
+	"fmt"
 	"sync"
 	"testing"
 )
@@ -9,6 +10,301 @@ const (
 	checkMark = "\u2713"
 	ballotX   = "\u2717"
 )
+
+func TestDefaultPayloadProvider_RegisterPayloadGenerationRequirement(t *testing.T) {
+
+	t.Log("given an actor's base and a payload generation requirement")
+	{
+		t.Log("\twhen actor invokes registration")
+		{
+			actorBaseName := "mapLoadRunner"
+			r := PayloadGenerationRequirement{}
+
+			dp := DefaultPayloadProvider{}
+			dp.RegisterPayloadGenerationRequirement(actorBaseName, r)
+
+			registeredRequirement, ok := dp.actorRequirements.Load(actorBaseName)
+			msg := "\t\tactor must have been registered"
+			if ok {
+				t.Log(msg, checkMark)
+			} else {
+				t.Fatal(msg, ballotX)
+			}
+
+			msg = "\t\tpayload generation requirement must have been inserted"
+			if registeredRequirement == r {
+				t.Log(msg, checkMark)
+			} else {
+				t.Fatal(msg, ballotX)
+			}
+		}
+	}
+
+}
+
+func TestDefaultPayloadProvider_RetrievePayload(t *testing.T) {
+
+	t.Log("given an actor name")
+	{
+		t.Log("\twhen no payload generation requirement corresponding to actor name is present")
+		{
+			dp := DefaultPayloadProvider{}
+
+			// Invoke retrieve method without previous registration of payload generation requirement for this
+			// actor's base name
+			p, err := dp.RetrievePayload("super-awesome-actor-name")
+
+			msg := "\t\terror must be returned"
+			if err != nil {
+				t.Log(msg, checkMark)
+			} else {
+				t.Fatal(msg, ballotX)
+			}
+
+			msg = "\t\treturned payload must be nil pointer"
+			if p == nil {
+				t.Log(msg, checkMark)
+			} else {
+				t.Fatal(msg, ballotX)
+			}
+		}
+
+		t.Log("\twhen payload generation requirement corresponding to actor name was previously registered")
+		{
+			t.Log("\t\twhen registered payload generation requirement enables both fixed-size and variable-size payloads")
+			{
+				dp := DefaultPayloadProvider{}
+
+				actorBaseName := "mapsLoadRunner"
+				dp.RegisterPayloadGenerationRequirement(actorBaseName, PayloadGenerationRequirement{
+					UseFixedSize:    true,
+					UseVariableSize: true,
+				})
+
+				actorExtendedName := fmt.Sprintf("%s-ht_load-0", actorBaseName)
+				p, err := dp.RetrievePayload(actorExtendedName)
+
+				msg := "\t\t\terror must be returned"
+				if err != nil {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX)
+				}
+
+				msg = "\t\t\treturned payload must be nil pointer"
+				if p == nil {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX)
+				}
+			}
+
+			t.Log("\t\twhen registered payload generation requirement enables only variable-size payload")
+			{
+				dp := DefaultPayloadProvider{}
+
+				actorBaseName := "mapLoadRunner"
+				r := PayloadGenerationRequirement{
+					UseVariableSize: true,
+					VariableSize: VariableSizePayloadDefinition{
+						LowerBoundaryBytes: 0,
+						UpperBoundaryBytes: 21,
+						SameSizeStepsLimit: 3,
+					},
+				}
+				dp.RegisterPayloadGenerationRequirement(actorBaseName, r)
+
+				p, err := dp.RetrievePayload(fmt.Sprintf("%s-ht_load-42", actorBaseName))
+
+				msg := "\t\t\tno error must be returned"
+				if err == nil {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX)
+				}
+
+				msg = "\t\t\treturned payload must correspond to boundaries specified by means of previously registered payload generation requirement"
+				if len(*p) >= r.VariableSize.LowerBoundaryBytes && len(*p) <= r.VariableSize.UpperBoundaryBytes {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX)
+				}
+			}
+
+			t.Log("\t\twhen registered payload generation requirement enables only fixed-size payload")
+			{
+				dp := DefaultPayloadProvider{}
+
+				actorBaseName := "mapsPokedexRunner"
+				r := PayloadGenerationRequirement{
+					UseFixedSize: true,
+					FixedSize: FixedSizePayloadDefinition{
+						SizeBytes: 42,
+					},
+				}
+
+				dp.RegisterPayloadGenerationRequirement(actorBaseName, r)
+
+				p, err := dp.RetrievePayload(fmt.Sprintf("%s-ht_load-42", actorBaseName))
+
+				msg := "\t\t\tno error must be returned"
+				if err == nil {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX)
+				}
+
+				msg = "\t\t\treturned payload must correspond to fixed size specified by means of previously registered payload generation requirement"
+				if len(*p) == r.FixedSize.SizeBytes {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX)
+				}
+			}
+		}
+	}
+
+}
+
+func TestDefaultPayloadProvider_findMatchingPayloadGenerationRequirement(t *testing.T) {
+
+	t.Log("given an actor name")
+	{
+		t.Log("\twhen no actor with corresponding base name has previously registered")
+		{
+			dp := DefaultPayloadProvider{}
+			// Register a couple of dummy actors
+			for _, a := range []string{"aragorn", "gimli", "legolas"} {
+				dp.RegisterPayloadGenerationRequirement(a, PayloadGenerationRequirement{
+					UseVariableSize: true,
+					VariableSize: VariableSizePayloadDefinition{
+						LowerBoundaryBytes: len(a),
+					},
+				})
+			}
+
+			r, err := dp.findMatchingPayloadGenerationRequirement("super-awesome-actor-name")
+
+			msg := "\t\terror must be returned"
+			if err != nil {
+				t.Log(msg, checkMark)
+			} else {
+				t.Fatal(msg, ballotX)
+			}
+
+			msg = "\t\treturned requirements value must represent empty requirement"
+			emptyRequirement := PayloadGenerationRequirement{}
+			if r == emptyRequirement {
+				t.Log(msg, checkMark)
+			} else {
+				t.Fatal(msg, ballotX)
+			}
+		}
+
+		t.Log("\twhen actor with corresponding base name has previously registered")
+		{
+			dp := DefaultPayloadProvider{}
+
+			registeredRequirement := PayloadGenerationRequirement{
+				UseVariableSize: true,
+				VariableSize: VariableSizePayloadDefinition{
+					LowerBoundaryBytes: 500,
+					UpperBoundaryBytes: 2000,
+					SameSizeStepsLimit: 250,
+				},
+			}
+
+			dp.RegisterPayloadGenerationRequirement("mapLoadRunner", registeredRequirement)
+			r, err := dp.findMatchingPayloadGenerationRequirement("mapLoadRunner-ht_load-0")
+
+			msg := "\t\tno error must be returned"
+			if err == nil {
+				t.Log(msg, checkMark)
+			} else {
+				t.Fatal(msg, ballotX)
+			}
+
+			msg = "\t\trequirement corresponding to actor name must be returned"
+			if r == registeredRequirement {
+				t.Log(msg, checkMark)
+			} else {
+				t.Fatal(msg, ballotX, r)
+			}
+
+		}
+	}
+
+}
+
+func TestInitializeAndReturnFixedSizePayload(t *testing.T) {
+
+	t.Log("given an actor name and a payload generation requirement")
+	{
+		t.Log("\twhen payload with given size wasn't previously initialized")
+		{
+			r := PayloadGenerationRequirement{
+				FixedSize: FixedSizePayloadDefinition{
+					SizeBytes: 42,
+				},
+			}
+			p, err := initializeAndReturnFixedSizePayload("awesome-actor-name", r)
+
+			msg := "\t\tno error must be returned"
+			if err == nil {
+				t.Log(msg, checkMark)
+			} else {
+				t.Fatal(msg, ballotX)
+			}
+
+			msg = "\t\treturned payload must match expected size"
+			if len(*p) == r.FixedSize.SizeBytes {
+				t.Log(msg, checkMark)
+			} else {
+				t.Fatal(msg, ballotX)
+			}
+
+			msg = "\t\tfixed-size payload must have been associated with size in store"
+			v, ok := fixedSizePayloads.Load(r.FixedSize.SizeBytes)
+			stored := v.(*string)
+
+			if ok && stored == p {
+				t.Log(msg, checkMark)
+			} else {
+				t.Fatal(msg, ballotX, fmt.Sprintf("%v != %v", p, stored))
+			}
+		}
+
+		t.Log("\twhen payload with given size was already initialized")
+		{
+			// Manually insert payload into store
+			previouslyInitializedPayload := "super-awesome-payload"
+			sizeBytes := len(previouslyInitializedPayload)
+			pointer := &previouslyInitializedPayload
+			fixedSizePayloads.Store(sizeBytes, pointer)
+
+			p, err := initializeAndReturnFixedSizePayload("some-actor-name", PayloadGenerationRequirement{
+				FixedSize: FixedSizePayloadDefinition{
+					SizeBytes: sizeBytes,
+				},
+			})
+
+			msg := "\t\tno error must be returned"
+			if err == nil {
+				t.Log(msg, checkMark)
+			} else {
+				t.Fatal(msg, ballotX)
+			}
+
+			msg = "\t\treturned pointer must point to payload previously initialized for given size"
+			if p == pointer {
+				t.Log(msg, checkMark)
+			} else {
+				t.Fatal(msg, ballotX)
+			}
+		}
+	}
+
+}
 
 func TestGenerateRandomStringPayloadWithinBoundary(t *testing.T) {
 
@@ -143,107 +439,6 @@ func TestGenerateRandomStringPayloadWithinBoundary(t *testing.T) {
 				}
 
 				previouslyGeneratedPayload = *p
-			}
-
-		}
-	}
-
-}
-
-func TestDefaultPayloadProvider_RegisterPayloadGenerationRequirement(t *testing.T) {
-
-	t.Log("given an actor's base and a payload generation requirement")
-	{
-		t.Log("\twhen actor invokes registration")
-		{
-			actorBaseName := "mapLoadRunner"
-			r := PayloadGenerationRequirement{}
-
-			dp := DefaultPayloadProvider{}
-			dp.RegisterPayloadGenerationRequirement(actorBaseName, r)
-
-			registeredRequirement, ok := dp.actorRequirements.Load(actorBaseName)
-			msg := "\t\tactor must have been registered"
-			if ok {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX)
-			}
-
-			msg = "\t\tpayload generation requirement must have been inserted"
-			if registeredRequirement == r {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX)
-			}
-		}
-	}
-
-}
-
-func TestDefaultPayloadProvider_findMatchingPayloadGenerationRequirement(t *testing.T) {
-
-	t.Log("given an actor name")
-	{
-		t.Log("\twhen no actor with corresponding base name has previously registered")
-		{
-			dp := DefaultPayloadProvider{}
-			// Register a couple of dummy actors
-			for _, a := range []string{"aragorn", "gimli", "legolas"} {
-				dp.RegisterPayloadGenerationRequirement(a, PayloadGenerationRequirement{
-					UseVariableSize: true,
-					VariableSize: VariableSizePayloadDefinition{
-						LowerBoundaryBytes: len(a),
-					},
-				})
-			}
-
-			r, err := dp.findMatchingPayloadGenerationRequirement("super-awesome-actor-name")
-
-			msg := "\t\terror must be returned"
-			if err != nil {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX)
-			}
-
-			msg = "\t\treturned requirements value must represent empty requirement"
-			emptyRequirement := PayloadGenerationRequirement{}
-			if r == emptyRequirement {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX)
-			}
-		}
-
-		t.Log("\twhen actor with corresponding base name has previously registered")
-		{
-			dp := DefaultPayloadProvider{}
-
-			registeredRequirement := PayloadGenerationRequirement{
-				UseVariableSize: true,
-				VariableSize: VariableSizePayloadDefinition{
-					LowerBoundaryBytes: 500,
-					UpperBoundaryBytes: 2000,
-					SameSizeStepsLimit: 250,
-				},
-			}
-
-			dp.RegisterPayloadGenerationRequirement("mapLoadRunner", registeredRequirement)
-			r, err := dp.findMatchingPayloadGenerationRequirement("mapLoadRunner-ht_load-0")
-
-			msg := "\t\tno error must be returned"
-			if err == nil {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX)
-			}
-
-			msg = "\t\trequirement corresponding to actor name must be returned"
-			if r == registeredRequirement {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX, r)
 			}
 
 		}

--- a/loadsupport/payloadgenerator_test.go
+++ b/loadsupport/payloadgenerator_test.go
@@ -42,14 +42,14 @@ func TestGenerateTrackedRandomStringPayloadWithinBoundary(t *testing.T) {
 				actorBaseName := "mapLoadRunner"
 				actorExtendedName := "mapLoadRunner-ht_load-0"
 
-				ActorTracker = PayloadConsumingActorTracker{}
+				ActorTracker = VariablePayloadConsumingActorTracker{}
 
-				registeredRequirement := PayloadGenerationRequirement{
+				registeredRequirement := VariablePayloadGenerationRequirement{
 					LowerBoundaryBytes: 0,
 					UpperBoundaryBytes: 10,
 					SameSizeStepsLimit: 5,
 				}
-				RegisterPayloadGenerationRequirement(actorBaseName, registeredRequirement)
+				RegisterVariablePayloadGenerationRequirement(actorBaseName, registeredRequirement)
 
 				p, err := GenerateTrackedRandomStringPayloadWithinBoundary(actorExtendedName)
 
@@ -76,7 +76,7 @@ func TestGenerateTrackedRandomStringPayloadWithinBoundary(t *testing.T) {
 				}
 
 				msg = "\t\t\tnumber of invocations must have been updated in payload generation info for this actor"
-				insertedInfo := v.(PayloadGenerationInfo)
+				insertedInfo := v.(VariablePayloadGenerationInfo)
 				if insertedInfo.numGeneratePayloadInvocations == 1 {
 					t.Log(msg, checkMark)
 				} else {
@@ -98,14 +98,14 @@ func TestGenerateTrackedRandomStringPayloadWithinBoundary(t *testing.T) {
 				actorBaseName := "mapLoadRunner"
 				actorExtendedName := "mapLoadRunner-ht_load-0"
 
-				ActorTracker = PayloadConsumingActorTracker{}
+				ActorTracker = VariablePayloadConsumingActorTracker{}
 
-				registeredRequirement := PayloadGenerationRequirement{
+				registeredRequirement := VariablePayloadGenerationRequirement{
 					LowerBoundaryBytes: 0,
 					UpperBoundaryBytes: 5001,
 					SameSizeStepsLimit: 6,
 				}
-				RegisterPayloadGenerationRequirement(actorBaseName, registeredRequirement)
+				RegisterVariablePayloadGenerationRequirement(actorBaseName, registeredRequirement)
 
 				previouslyGeneratedPayload := ""
 				for i := 0; i < registeredRequirement.SameSizeStepsLimit+1; i++ {
@@ -121,7 +121,7 @@ func TestGenerateTrackedRandomStringPayloadWithinBoundary(t *testing.T) {
 					msg = "\t\t\tnumber of invocations must have been updated in payload generation info for this actor"
 					v, _ := payloadConsumingActors.Load(actorExtendedName)
 
-					payloadGenerationInfo := v.(PayloadGenerationInfo)
+					payloadGenerationInfo := v.(VariablePayloadGenerationInfo)
 
 					var expectedTrackedNumberOfInvocations int
 					if i < registeredRequirement.SameSizeStepsLimit {
@@ -181,10 +181,10 @@ func TestPayloadConsumingActorTracker_findMatchingRequirement(t *testing.T) {
 	{
 		t.Log("\twhen no actor with corresponding base name has previously registered")
 		{
-			ActorTracker = PayloadConsumingActorTracker{}
+			ActorTracker = VariablePayloadConsumingActorTracker{}
 			// Register a couple of dummy actors
 			for _, a := range []string{"aragorn", "gimli", "legolas"} {
-				RegisterPayloadGenerationRequirement(a, PayloadGenerationRequirement{LowerBoundaryBytes: len(a)})
+				RegisterVariablePayloadGenerationRequirement(a, VariablePayloadGenerationRequirement{LowerBoundaryBytes: len(a)})
 			}
 
 			r, err := ActorTracker.FindMatchingPayloadGenerationRequirement("super-awesome-actor-name")
@@ -197,7 +197,7 @@ func TestPayloadConsumingActorTracker_findMatchingRequirement(t *testing.T) {
 			}
 
 			msg = "\t\treturned requirements value must represent empty requirement"
-			emptyRequirement := PayloadGenerationRequirement{}
+			emptyRequirement := VariablePayloadGenerationRequirement{}
 			if r == emptyRequirement {
 				t.Log(msg, checkMark)
 			} else {
@@ -207,17 +207,17 @@ func TestPayloadConsumingActorTracker_findMatchingRequirement(t *testing.T) {
 
 		t.Log("\twhen actor with corresponding base name has previously registered")
 		{
-			ActorTracker = PayloadConsumingActorTracker{}
+			ActorTracker = VariablePayloadConsumingActorTracker{}
 
 			actorBaseName := "mapLoadRunner"
-			registeredRequirement := PayloadGenerationRequirement{
+			registeredRequirement := VariablePayloadGenerationRequirement{
 				LowerBoundaryBytes: 500,
 				UpperBoundaryBytes: 2000,
 				SameSizeStepsLimit: 250,
 			}
-			RegisterPayloadGenerationRequirement(actorBaseName, registeredRequirement)
+			RegisterVariablePayloadGenerationRequirement(actorBaseName, registeredRequirement)
 
-			RegisterPayloadGenerationRequirement("mapPokedexRunner", PayloadGenerationRequirement{})
+			RegisterVariablePayloadGenerationRequirement("mapPokedexRunner", VariablePayloadGenerationRequirement{})
 
 			r, err := ActorTracker.FindMatchingPayloadGenerationRequirement("mapLoadRunner-ht_load-0")
 
@@ -247,9 +247,9 @@ func TestRegisterPayloadGenerationRequirement(t *testing.T) {
 		t.Log("\twhen actor invokes registration")
 		{
 			actorBaseName := "mapLoadRunner"
-			r := PayloadGenerationRequirement{}
+			r := VariablePayloadGenerationRequirement{}
 
-			RegisterPayloadGenerationRequirement(actorBaseName, r)
+			RegisterVariablePayloadGenerationRequirement(actorBaseName, r)
 
 			registered, ok := ActorTracker.actors.Load(actorBaseName)
 			msg := "\t\tactor must have been registered"

--- a/loadsupport/payloadgenerator_test.go
+++ b/loadsupport/payloadgenerator_test.go
@@ -39,6 +39,30 @@ func TestDefaultPayloadProvider_RegisterPayloadGenerationRequirement(t *testing.
 			}
 		}
 	}
+	t.Log("given many actors wishing to register payload generation requirements")
+	{
+		actorBaseName := "mapLoadRunner"
+		numActors := 100
+
+		var wg sync.WaitGroup
+		dp := &DefaultPayloadProvider{}
+		r := PayloadGenerationRequirement{
+			UseVariableSize: true,
+			VariableSize: VariableSizePayloadDefinition{
+				LowerBoundaryBytes: 1000,
+				UpperBoundaryBytes: 2000000,
+				SameSizeStepsLimit: 100,
+			},
+		}
+		for i := 0; i < numActors; i++ {
+			go func(actorIndex int) {
+				defer wg.Done()
+				dp.RegisterPayloadGenerationRequirement(fmt.Sprintf("%s-ht_load-%d", actorBaseName, actorIndex), r)
+			}(i)
+		}
+		wg.Wait()
+
+	}
 
 }
 

--- a/loadsupport/payloadgenerator_test.go
+++ b/loadsupport/payloadgenerator_test.go
@@ -26,7 +26,7 @@ func TestGenerateTrackedRandomStringPayloadWithinBoundary(t *testing.T) {
 			}
 
 			msg = "\t\tempty string must be returned"
-			if p == "" {
+			if p == nil {
 				t.Log(msg, checkMark)
 			} else {
 				t.Fatal(msg, ballotX)
@@ -61,7 +61,7 @@ func TestGenerateTrackedRandomStringPayloadWithinBoundary(t *testing.T) {
 				}
 
 				msg = "\t\t\tsize of generated payload must correspond to previously registered payload generation requirement"
-				if len(p) >= registeredRequirement.LowerBoundaryBytes && len(p) <= registeredRequirement.UpperBoundaryBytes {
+				if len(*p) >= registeredRequirement.LowerBoundaryBytes && len(*p) <= registeredRequirement.UpperBoundaryBytes {
 					t.Log(msg, checkMark)
 				} else {
 					t.Fatal(msg, ballotX)
@@ -84,7 +84,7 @@ func TestGenerateTrackedRandomStringPayloadWithinBoundary(t *testing.T) {
 				}
 
 				msg = "\t\t\tpayload generation info must contain size of generated payload"
-				if insertedInfo.payloadSize == len(p) {
+				if insertedInfo.payloadSize == len(*p) {
 					t.Log(msg, checkMark)
 				} else {
 					t.Fatal(msg, ballotX)
@@ -138,7 +138,7 @@ func TestGenerateTrackedRandomStringPayloadWithinBoundary(t *testing.T) {
 
 					if i == 0 {
 						msg = "\t\t\tsize of generated payload must correspond to previously registered payload generation requirement"
-						if len(p) > registeredRequirement.LowerBoundaryBytes && len(p) <= registeredRequirement.UpperBoundaryBytes {
+						if len(*p) > registeredRequirement.LowerBoundaryBytes && len(*p) <= registeredRequirement.UpperBoundaryBytes {
 							t.Log(msg, checkMark, i)
 						} else {
 							t.Fatal(msg, ballotX, i)
@@ -147,7 +147,7 @@ func TestGenerateTrackedRandomStringPayloadWithinBoundary(t *testing.T) {
 						t.Log("\t\t\twhen number of invocations is within same size step boundary")
 						{
 							msg = "\t\t\t\tpayload's size must be equal to previous generated payload's size"
-							if len(p) == len(previouslyGeneratedPayload) {
+							if len(*p) == len(previouslyGeneratedPayload) {
 								t.Log(msg, checkMark, i)
 							} else {
 								t.Fatal(msg, ballotX, i)
@@ -157,7 +157,7 @@ func TestGenerateTrackedRandomStringPayloadWithinBoundary(t *testing.T) {
 						t.Log("\t\t\twhen number of invocations exceeds same size step boundary")
 						{
 							msg = "\t\t\t\tpayload's size must differ from previously generated payload's size"
-							if len(p) != len(previouslyGeneratedPayload) {
+							if len(*p) != len(previouslyGeneratedPayload) {
 								t.Log(msg, checkMark, i)
 							} else {
 								t.Fatal(msg, ballotX, i)
@@ -165,7 +165,7 @@ func TestGenerateTrackedRandomStringPayloadWithinBoundary(t *testing.T) {
 						}
 					}
 
-					previouslyGeneratedPayload = p
+					previouslyGeneratedPayload = *p
 				}
 
 			}

--- a/loadsupport/payloadgenerator_test.go
+++ b/loadsupport/payloadgenerator_test.go
@@ -10,184 +10,195 @@ const (
 	ballotX   = "\u2717"
 )
 
-func TestGenerateTrackedRandomStringPayloadWithinBoundary(t *testing.T) {
+func TestGenerateRandomStringPayloadWithinBoundary(t *testing.T) {
 
-	t.Log("given an actor name")
+	t.Log("given an actor name and a payload generation requirement")
 	{
-		t.Log("\twhen no actor with matching name has previously registered a payload generation requirement")
+		t.Log("\twhen given actor has not previously invoked payload generation yet")
 		{
-			p, err := GenerateTrackedRandomStringPayloadWithinBoundary("awesome-actor")
+			payloadConsumingActors = sync.Map{}
 
-			msg := "\t\terror must be returned"
-			if err != nil {
+			actorExtendedName := "mapLoadRunner-ht_load-0"
+
+			r := PayloadGenerationRequirement{
+				UseVariableSize: true,
+				VariableSize: VariableSizePayloadDefinition{
+					LowerBoundaryBytes: 0,
+					UpperBoundaryBytes: 10,
+					SameSizeStepsLimit: 5,
+				},
+			}
+
+			p, err := generateRandomStringPayloadWithinBoundary(actorExtendedName, r)
+
+			msg := "\t\tno error must be returned"
+			if err == nil {
 				t.Log(msg, checkMark)
 			} else {
 				t.Fatal(msg, ballotX)
 			}
 
-			msg = "\t\tempty string must be returned"
-			if p == nil {
+			msg = "\t\tsize of generated payload must correspond to boundaries provided in given payload generation requirement"
+			if len(*p) >= r.VariableSize.LowerBoundaryBytes && len(*p) <= r.VariableSize.UpperBoundaryBytes {
+				t.Log(msg, checkMark)
+			} else {
+				t.Fatal(msg, ballotX)
+			}
+
+			msg = "\t\tnew payload generation info value must have been inserted"
+			v, ok := payloadConsumingActors.Load(actorExtendedName)
+			if ok {
+				t.Log(msg, checkMark)
+			} else {
+				t.Fatal(msg, ballotX)
+			}
+
+			msg = "\t\tnumber of invocations must have been updated in payload generation info for this actor"
+			insertedInfo := v.(VariablePayloadGenerationInfo)
+			if insertedInfo.numGeneratePayloadInvocations == 1 {
+				t.Log(msg, checkMark)
+			} else {
+				t.Fatal(msg, ballotX)
+			}
+
+			msg = "\t\tpayload generation info must contain size of generated payload"
+			if insertedInfo.payloadSize == len(*p) {
 				t.Log(msg, checkMark)
 			} else {
 				t.Fatal(msg, ballotX)
 			}
 		}
 
-		t.Log("\twhen actor has previously registered")
+		t.Log("\twhen given actor has previously invoked payload generation")
 		{
-			t.Log("\t\twhen given actor has not previously invoked payload generation yet")
-			{
-				payloadConsumingActors = sync.Map{}
+			payloadConsumingActors = sync.Map{}
 
-				actorBaseName := "mapLoadRunner"
-				actorExtendedName := "mapLoadRunner-ht_load-0"
+			actorExtendedName := "mapLoadRunner-ht_load-0"
 
-				ActorTracker = VariablePayloadConsumingActorTracker{}
-
-				registeredRequirement := VariablePayloadGenerationRequirement{
-					LowerBoundaryBytes: 0,
-					UpperBoundaryBytes: 10,
-					SameSizeStepsLimit: 5,
-				}
-				RegisterVariablePayloadGenerationRequirement(actorBaseName, registeredRequirement)
-
-				p, err := GenerateTrackedRandomStringPayloadWithinBoundary(actorExtendedName)
-
-				msg := "\t\t\tno error must be returned"
-				if err == nil {
-					t.Log(msg, checkMark)
-				} else {
-					t.Fatal(msg, ballotX)
-				}
-
-				msg = "\t\t\tsize of generated payload must correspond to previously registered payload generation requirement"
-				if len(*p) >= registeredRequirement.LowerBoundaryBytes && len(*p) <= registeredRequirement.UpperBoundaryBytes {
-					t.Log(msg, checkMark)
-				} else {
-					t.Fatal(msg, ballotX)
-				}
-
-				msg = "\t\t\tnew payload generation info value must have been inserted"
-				v, ok := payloadConsumingActors.Load(actorExtendedName)
-				if ok {
-					t.Log(msg, checkMark)
-				} else {
-					t.Fatal(msg, ballotX)
-				}
-
-				msg = "\t\t\tnumber of invocations must have been updated in payload generation info for this actor"
-				insertedInfo := v.(VariablePayloadGenerationInfo)
-				if insertedInfo.numGeneratePayloadInvocations == 1 {
-					t.Log(msg, checkMark)
-				} else {
-					t.Fatal(msg, ballotX)
-				}
-
-				msg = "\t\t\tpayload generation info must contain size of generated payload"
-				if insertedInfo.payloadSize == len(*p) {
-					t.Log(msg, checkMark)
-				} else {
-					t.Fatal(msg, ballotX)
-				}
-			}
-
-			t.Log("\t\twhen given actor has previously invoked payload generation")
-			{
-				payloadConsumingActors = sync.Map{}
-
-				actorBaseName := "mapLoadRunner"
-				actorExtendedName := "mapLoadRunner-ht_load-0"
-
-				ActorTracker = VariablePayloadConsumingActorTracker{}
-
-				registeredRequirement := VariablePayloadGenerationRequirement{
+			r := PayloadGenerationRequirement{
+				UseVariableSize: true,
+				VariableSize: VariableSizePayloadDefinition{
 					LowerBoundaryBytes: 0,
 					UpperBoundaryBytes: 5001,
 					SameSizeStepsLimit: 6,
+				},
+			}
+
+			previouslyGeneratedPayload := ""
+			for i := 0; i < r.VariableSize.SameSizeStepsLimit+1; i++ {
+				p, err := generateRandomStringPayloadWithinBoundary(actorExtendedName, r)
+
+				msg := "\t\tno error must be returned"
+				if err == nil {
+					t.Log(msg, checkMark, i)
+				} else {
+					t.Fatal(msg, ballotX, i)
 				}
-				RegisterVariablePayloadGenerationRequirement(actorBaseName, registeredRequirement)
 
-				previouslyGeneratedPayload := ""
-				for i := 0; i < registeredRequirement.SameSizeStepsLimit+1; i++ {
-					p, err := GenerateTrackedRandomStringPayloadWithinBoundary(actorExtendedName)
+				msg = "\t\tnumber of invocations must have been updated in payload generation info for this actor"
+				v, _ := payloadConsumingActors.Load(actorExtendedName)
 
-					msg := "\t\t\tno error must be returned"
-					if err == nil {
+				payloadGenerationInfo := v.(VariablePayloadGenerationInfo)
+
+				var expectedTrackedNumberOfInvocations int
+				if i < r.VariableSize.SameSizeStepsLimit {
+					expectedTrackedNumberOfInvocations = i + 1
+				} else {
+					expectedTrackedNumberOfInvocations = 1
+				}
+
+				if payloadGenerationInfo.numGeneratePayloadInvocations == expectedTrackedNumberOfInvocations {
+					t.Log(msg, checkMark, i)
+				} else {
+					t.Fatal(msg, ballotX, i, payloadGenerationInfo.numGeneratePayloadInvocations)
+				}
+
+				if i == 0 {
+					msg = "\t\t\tsize of generated payload must correspond to previously registered payload generation requirement"
+					if len(*p) > r.VariableSize.LowerBoundaryBytes && len(*p) <= r.VariableSize.UpperBoundaryBytes {
 						t.Log(msg, checkMark, i)
 					} else {
 						t.Fatal(msg, ballotX, i)
 					}
-
-					msg = "\t\t\tnumber of invocations must have been updated in payload generation info for this actor"
-					v, _ := payloadConsumingActors.Load(actorExtendedName)
-
-					payloadGenerationInfo := v.(VariablePayloadGenerationInfo)
-
-					var expectedTrackedNumberOfInvocations int
-					if i < registeredRequirement.SameSizeStepsLimit {
-						expectedTrackedNumberOfInvocations = i + 1
-					} else {
-						expectedTrackedNumberOfInvocations = 1
-					}
-
-					if payloadGenerationInfo.numGeneratePayloadInvocations == expectedTrackedNumberOfInvocations {
-						t.Log(msg, checkMark, i)
-					} else {
-						t.Fatal(msg, ballotX, i, payloadGenerationInfo.numGeneratePayloadInvocations)
-					}
-
-					if i == 0 {
-						msg = "\t\t\tsize of generated payload must correspond to previously registered payload generation requirement"
-						if len(*p) > registeredRequirement.LowerBoundaryBytes && len(*p) <= registeredRequirement.UpperBoundaryBytes {
+				} else if i < r.VariableSize.SameSizeStepsLimit {
+					t.Log("\t\t\twhen number of invocations is within same size step boundary")
+					{
+						msg = "\t\t\t\tpayload's size must be equal to previous generated payload's size"
+						if len(*p) == len(previouslyGeneratedPayload) {
 							t.Log(msg, checkMark, i)
 						} else {
 							t.Fatal(msg, ballotX, i)
 						}
-					} else if i < registeredRequirement.SameSizeStepsLimit {
-						t.Log("\t\t\twhen number of invocations is within same size step boundary")
-						{
-							msg = "\t\t\t\tpayload's size must be equal to previous generated payload's size"
-							if len(*p) == len(previouslyGeneratedPayload) {
-								t.Log(msg, checkMark, i)
-							} else {
-								t.Fatal(msg, ballotX, i)
-							}
-						}
-					} else {
-						t.Log("\t\t\twhen number of invocations exceeds same size step boundary")
-						{
-							msg = "\t\t\t\tpayload's size must differ from previously generated payload's size"
-							if len(*p) != len(previouslyGeneratedPayload) {
-								t.Log(msg, checkMark, i)
-							} else {
-								t.Fatal(msg, ballotX, i)
-							}
+					}
+				} else {
+					t.Log("\t\t\twhen number of invocations exceeds same size step boundary")
+					{
+						msg = "\t\t\t\tpayload's size must differ from previously generated payload's size"
+						if len(*p) != len(previouslyGeneratedPayload) {
+							t.Log(msg, checkMark, i)
+						} else {
+							t.Fatal(msg, ballotX, i)
 						}
 					}
-
-					previouslyGeneratedPayload = *p
 				}
 
+				previouslyGeneratedPayload = *p
 			}
-		}
 
+		}
 	}
 
 }
 
-func TestPayloadConsumingActorTracker_findMatchingRequirement(t *testing.T) {
+func TestDefaultPayloadProvider_RegisterPayloadGenerationRequirement(t *testing.T) {
+
+	t.Log("given an actor's base and a payload generation requirement")
+	{
+		t.Log("\twhen actor invokes registration")
+		{
+			actorBaseName := "mapLoadRunner"
+			r := PayloadGenerationRequirement{}
+
+			dp := DefaultPayloadProvider{}
+			dp.RegisterPayloadGenerationRequirement(actorBaseName, r)
+
+			registeredRequirement, ok := dp.actorRequirements.Load(actorBaseName)
+			msg := "\t\tactor must have been registered"
+			if ok {
+				t.Log(msg, checkMark)
+			} else {
+				t.Fatal(msg, ballotX)
+			}
+
+			msg = "\t\tpayload generation requirement must have been inserted"
+			if registeredRequirement == r {
+				t.Log(msg, checkMark)
+			} else {
+				t.Fatal(msg, ballotX)
+			}
+		}
+	}
+
+}
+
+func TestDefaultPayloadProvider_findMatchingPayloadGenerationRequirement(t *testing.T) {
 
 	t.Log("given an actor name")
 	{
 		t.Log("\twhen no actor with corresponding base name has previously registered")
 		{
-			ActorTracker = VariablePayloadConsumingActorTracker{}
+			dp := DefaultPayloadProvider{}
 			// Register a couple of dummy actors
 			for _, a := range []string{"aragorn", "gimli", "legolas"} {
-				RegisterVariablePayloadGenerationRequirement(a, VariablePayloadGenerationRequirement{LowerBoundaryBytes: len(a)})
+				dp.RegisterPayloadGenerationRequirement(a, PayloadGenerationRequirement{
+					UseVariableSize: true,
+					VariableSize: VariableSizePayloadDefinition{
+						LowerBoundaryBytes: len(a),
+					},
+				})
 			}
 
-			r, err := ActorTracker.FindMatchingVariableSizePayloadGenerationRequirement("super-awesome-actor-name")
+			r, err := dp.findMatchingPayloadGenerationRequirement("super-awesome-actor-name")
 
 			msg := "\t\terror must be returned"
 			if err != nil {
@@ -197,7 +208,7 @@ func TestPayloadConsumingActorTracker_findMatchingRequirement(t *testing.T) {
 			}
 
 			msg = "\t\treturned requirements value must represent empty requirement"
-			emptyRequirement := VariablePayloadGenerationRequirement{}
+			emptyRequirement := PayloadGenerationRequirement{}
 			if r == emptyRequirement {
 				t.Log(msg, checkMark)
 			} else {
@@ -207,19 +218,19 @@ func TestPayloadConsumingActorTracker_findMatchingRequirement(t *testing.T) {
 
 		t.Log("\twhen actor with corresponding base name has previously registered")
 		{
-			ActorTracker = VariablePayloadConsumingActorTracker{}
+			dp := DefaultPayloadProvider{}
 
-			actorBaseName := "mapLoadRunner"
-			registeredRequirement := VariablePayloadGenerationRequirement{
-				LowerBoundaryBytes: 500,
-				UpperBoundaryBytes: 2000,
-				SameSizeStepsLimit: 250,
+			registeredRequirement := PayloadGenerationRequirement{
+				UseVariableSize: true,
+				VariableSize: VariableSizePayloadDefinition{
+					LowerBoundaryBytes: 500,
+					UpperBoundaryBytes: 2000,
+					SameSizeStepsLimit: 250,
+				},
 			}
-			RegisterVariablePayloadGenerationRequirement(actorBaseName, registeredRequirement)
 
-			RegisterVariablePayloadGenerationRequirement("mapPokedexRunner", VariablePayloadGenerationRequirement{})
-
-			r, err := ActorTracker.FindMatchingVariableSizePayloadGenerationRequirement("mapLoadRunner-ht_load-0")
+			dp.RegisterPayloadGenerationRequirement("mapLoadRunner", registeredRequirement)
+			r, err := dp.findMatchingPayloadGenerationRequirement("mapLoadRunner-ht_load-0")
 
 			msg := "\t\tno error must be returned"
 			if err == nil {
@@ -235,36 +246,6 @@ func TestPayloadConsumingActorTracker_findMatchingRequirement(t *testing.T) {
 				t.Fatal(msg, ballotX, r)
 			}
 
-		}
-	}
-
-}
-
-func TestRegisterPayloadGenerationRequirement(t *testing.T) {
-
-	t.Log("given an actor's base and a payload generation requirement")
-	{
-		t.Log("\twhen actor invokes registration")
-		{
-			actorBaseName := "mapLoadRunner"
-			r := VariablePayloadGenerationRequirement{}
-
-			RegisterVariablePayloadGenerationRequirement(actorBaseName, r)
-
-			registered, ok := ActorTracker.actors.Load(actorBaseName)
-			msg := "\t\tactor must have been registered"
-			if ok {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX)
-			}
-
-			msg = "\t\tpayload generation requirement must have been inserted"
-			if registered == r {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX)
-			}
 		}
 	}
 

--- a/loadsupport/payloadgenerator_test.go
+++ b/loadsupport/payloadgenerator_test.go
@@ -187,7 +187,7 @@ func TestPayloadConsumingActorTracker_findMatchingRequirement(t *testing.T) {
 				RegisterVariablePayloadGenerationRequirement(a, VariablePayloadGenerationRequirement{LowerBoundaryBytes: len(a)})
 			}
 
-			r, err := ActorTracker.FindMatchingPayloadGenerationRequirement("super-awesome-actor-name")
+			r, err := ActorTracker.FindMatchingVariableSizePayloadGenerationRequirement("super-awesome-actor-name")
 
 			msg := "\t\terror must be returned"
 			if err != nil {
@@ -219,7 +219,7 @@ func TestPayloadConsumingActorTracker_findMatchingRequirement(t *testing.T) {
 
 			RegisterVariablePayloadGenerationRequirement("mapPokedexRunner", VariablePayloadGenerationRequirement{})
 
-			r, err := ActorTracker.FindMatchingPayloadGenerationRequirement("mapLoadRunner-ht_load-0")
+			r, err := ActorTracker.FindMatchingVariableSizePayloadGenerationRequirement("mapLoadRunner-ht_load-0")
 
 			msg := "\t\tno error must be returned"
 			if err == nil {

--- a/loadsupport/payloadgenerator_test.go
+++ b/loadsupport/payloadgenerator_test.go
@@ -350,7 +350,7 @@ func TestGenerateRandomStringPayloadWithinBoundary(t *testing.T) {
 			}
 
 			msg = "\t\tnumber of invocations must have been updated in payload generation info for this actor"
-			insertedInfo := v.(VariablePayloadGenerationInfo)
+			insertedInfo := v.(variablePayloadGenerationInfo)
 			if insertedInfo.numGeneratePayloadInvocations == 1 {
 				t.Log(msg, checkMark)
 			} else {
@@ -394,7 +394,7 @@ func TestGenerateRandomStringPayloadWithinBoundary(t *testing.T) {
 				msg = "\t\tnumber of invocations must have been updated in payload generation info for this actor"
 				v, _ := payloadConsumingActors.Load(actorExtendedName)
 
-				payloadGenerationInfo := v.(VariablePayloadGenerationInfo)
+				payloadGenerationInfo := v.(variablePayloadGenerationInfo)
 
 				var expectedTrackedNumberOfInvocations int
 				if i < r.VariableSize.SameSizeStepsLimit {

--- a/maps/loadrunner.go
+++ b/maps/loadrunner.go
@@ -160,7 +160,7 @@ func (r *loadRunner) runMapTests(ctx context.Context, hzCluster string, hzMember
 		elements:             loadElements,
 		ctx:                  ctx,
 		getElementID:         getLoadElementID,
-		getOrAssemblePayload: getOrAssemblePayload,
+		getOrAssemblePayload: getOrAssemblePayloadWrapper,
 	}
 
 	r.l.init(tle, &defaultSleeper{}, r.gatherer)
@@ -211,17 +211,21 @@ func populateLoadElements(numElementsToPopulate int, payloadSizeBytes int) []loa
 
 }
 
-func getOrAssemblePayload(mapName string, mapNumber uint16, element any) (any, error) {
+func getOrAssemblePayloadWrapper(mapName string, mapNumber uint16, element any) (any, error) {
+	return getOrAssemblePayload(mapName, mapNumber, element)
+}
+
+func getOrAssemblePayload(mapName string, mapNumber uint16, element any) (*string, error) {
 
 	if useFixedPayload && useVariablePayload {
-		return "", errors.New("instructions unclear: both fixed-size and variable-size payloads enabled")
+		return nil, errors.New("instructions unclear: both fixed-size and variable-size payloads enabled")
 	}
 
 	l := element.(loadElement)
 
 	if useFixedPayload {
-		if len(*l.Payload) == 0 {
-			return "", errors.New("fixed-size payloads have been enabled, but no payload of fixed size was provided in load element")
+		if l.Payload == nil || len(*l.Payload) == 0 {
+			return nil, errors.New("fixed-size payloads have been enabled, but no payload of fixed size was provided in load element")
 		}
 		return l.Payload, nil
 	}
@@ -232,7 +236,7 @@ func getOrAssemblePayload(mapName string, mapNumber uint16, element any) (any, e
 		)
 	}
 
-	return "", errors.New("instructions unclear: neither fixed-size nor variable-size payloads enabled")
+	return nil, errors.New("instructions unclear: neither fixed-size nor variable-size payloads enabled")
 
 }
 

--- a/maps/loadrunner.go
+++ b/maps/loadrunner.go
@@ -160,7 +160,7 @@ func (r *loadRunner) runMapTests(ctx context.Context, hzCluster string, hzMember
 		elements:             loadElements,
 		ctx:                  ctx,
 		getElementID:         getLoadElementID,
-		getOrAssemblePayload: getOrAssemblePayloadWrapper,
+		getOrAssemblePayload: getOrAssemblePayload,
 	}
 
 	r.l.init(tle, &defaultSleeper{}, r.gatherer)
@@ -196,7 +196,7 @@ func populateLoadElements(numElementsToPopulate int, payloadSizeBytes int) []loa
 
 	elements := make([]loadElement, numElementsToPopulate)
 	// Depending on the value of 'payloadSizeBytes', this string can get very large, and to generate one
-	// unique string for each map entry will result in high memory consumption of this Hazeltest client.
+	// unique string for each map entry would result in high memory consumption of this Hazeltest client.
 	// Thus, we use one random string for each map and reference that string in each load element
 	randomPayload := loadsupport.GenerateRandomStringPayload(payloadSizeBytes)
 
@@ -209,10 +209,6 @@ func populateLoadElements(numElementsToPopulate int, payloadSizeBytes int) []loa
 
 	return elements
 
-}
-
-func getOrAssemblePayloadWrapper(mapName string, mapNumber uint16, element any) (any, error) {
-	return getOrAssemblePayload(mapName, mapNumber, element)
 }
 
 func getOrAssemblePayload(mapName string, mapNumber uint16, element any) (*string, error) {

--- a/maps/loadrunner.go
+++ b/maps/loadrunner.go
@@ -160,17 +160,18 @@ func (r *loadRunner) runMapTests(ctx context.Context, hzCluster string, hzMember
 	lp.LogMapRunnerEvent("starting load test loop for maps", r.name, log.InfoLevel)
 
 	tle := &testLoopExecution[loadElement]{
-		id:                   uuid.New(),
-		runnerName:           r.name,
-		source:               r.source,
-		hzClientHandler:      r.hzClientHandler,
-		hzMapStore:           r.hzMapStore,
-		stateCleanerBuilder:  &state.DefaultSingleMapCleanerBuilder{},
-		runnerConfig:         config,
-		elements:             make([]loadElement, 0),
-		ctx:                  ctx,
-		getElementID:         getLoadElementID,
-		getOrAssemblePayload: r.getOrAssemblePayload,
+		id:                        uuid.New(),
+		runnerName:                r.name,
+		source:                    r.source,
+		hzClientHandler:           r.hzClientHandler,
+		hzMapStore:                r.hzMapStore,
+		stateCleanerBuilder:       &state.DefaultSingleMapCleanerBuilder{},
+		runnerConfig:              config,
+		elements:                  make([]loadElement, 0),
+		usePreInitializedElements: false,
+		ctx:                       ctx,
+		getElementID:              getLoadElementID,
+		getOrAssemblePayload:      r.getOrAssemblePayload,
 	}
 
 	r.l.init(tle, &defaultSleeper{}, r.gatherer)

--- a/maps/loadrunner.go
+++ b/maps/loadrunner.go
@@ -191,7 +191,7 @@ func (r *loadRunner) appendState(s runnerState) {
 
 }
 
-func (r *loadRunner) getOrAssemblePayload(mapName string, mapNumber uint16, _ string) (*string, error) {
+func (r *loadRunner) getOrAssemblePayload(mapName string, mapNumber uint16, _ string) (*loadsupport.PayloadWrapper, error) {
 
 	actorName := fmt.Sprintf("%s-%s-%d", mapLoadRunnerName, mapName, mapNumber)
 	return r.payloadProvider.RetrievePayload(actorName)

--- a/maps/loadrunner.go
+++ b/maps/loadrunner.go
@@ -2,7 +2,6 @@ package maps
 
 import (
 	"context"
-	"encoding/gob"
 	"errors"
 	"fmt"
 	"github.com/google/uuid"
@@ -66,7 +65,6 @@ func init() {
 			loadElementTestLoop newLoadElementTestLoopFunc
 		}{mapStore: newDefaultMapStore, loadElementTestLoop: newLoadElementTestLoop},
 	})
-	gob.Register(loadElement{})
 }
 
 func newLoadElementTestLoop(rc *runnerConfig) (looper[loadElement], error) {

--- a/maps/loadrunner.go
+++ b/maps/loadrunner.go
@@ -213,25 +213,19 @@ func populateLoadElements(numElementsToPopulate int, payloadSizeBytes int) []loa
 
 }
 
-func getOrAssemblePayload(mapName string, mapNumber uint16, element any) (*string, error) {
+func getOrAssemblePayload(mapName string, mapNumber uint16, _ string) (*string, error) {
 
 	if useFixedPayload && useVariablePayload {
 		return nil, errors.New("instructions unclear: both fixed-size and variable-size payloads enabled")
 	}
 
-	l := element.(loadElement)
-
+	actorName := fmt.Sprintf("%s-%s-%d", mapLoadRunnerName, mapName, mapNumber)
 	if useFixedPayload {
-		if l.Payload == nil || len(*l.Payload) == 0 {
-			return nil, errors.New("fixed-size payloads have been enabled, but no payload of fixed size was provided in load element")
-		}
-		return l.Payload, nil
+		return loadsupport.RetrieveInitializedFixedSizePayload(actorName)
 	}
 
 	if useVariablePayload {
-		return loadsupport.GenerateTrackedRandomStringPayloadWithinBoundary(
-			fmt.Sprintf("%s-%s-%d", mapLoadRunnerName, mapName, mapNumber),
-		)
+		return loadsupport.GenerateTrackedRandomStringPayloadWithinBoundary(actorName)
 	}
 
 	return nil, errors.New("instructions unclear: neither fixed-size nor variable-size payloads enabled")

--- a/maps/loadrunner.go
+++ b/maps/loadrunner.go
@@ -33,7 +33,7 @@ type (
 	}
 	loadElement struct {
 		Key     string
-		Payload string
+		Payload *string
 	}
 	newLoadElementTestLoopFunc func(rc *runnerConfig) (looper[loadElement], error)
 )
@@ -220,7 +220,7 @@ func getOrAssemblePayload(mapName string, mapNumber uint16, element any) (any, e
 	l := element.(loadElement)
 
 	if useFixedPayload {
-		if len(l.Payload) == 0 {
+		if len(*l.Payload) == 0 {
 			return "", errors.New("fixed-size payloads have been enabled, but no payload of fixed size was provided in load element")
 		}
 		return l.Payload, nil

--- a/maps/loadrunner_test.go
+++ b/maps/loadrunner_test.go
@@ -30,7 +30,7 @@ type (
 	}
 	testPayloadProviderBehavior struct {
 		returnErrorUponPayloadRetrieval bool
-		payloadsToReturn                map[string]*string
+		payloadsToReturn                map[string]*loadsupport.PayloadWrapper
 	}
 )
 
@@ -47,7 +47,7 @@ func (p *testPayloadProvider) RegisterPayloadGenerationRequirement(actorBaseName
 	p.observations.requirementRegistrations[actorBaseName] = r
 }
 
-func (p *testPayloadProvider) RetrievePayload(actorName string) (*string, error) {
+func (p *testPayloadProvider) RetrievePayload(actorName string) (*loadsupport.PayloadWrapper, error) {
 	p.observations.payloadRetrievals[actorName] = struct{}{}
 
 	if p.behavior.returnErrorUponPayloadRetrieval {
@@ -701,16 +701,15 @@ func TestLoadRunner_getOrAssemblePayload(t *testing.T) {
 			mapName := "awesome-map-name"
 			mapNumber := uint16(0)
 			actorName := fmt.Sprintf("%s-%s-%d", mapLoadRunnerName, mapName, mapNumber)
-			s := "super-awesome-payload"
-			payload := &s
+			pw := &loadsupport.PayloadWrapper{Payload: []byte("super-awesome-payload")}
 			tp := &testPayloadProvider{
 				observations: &testPayloadProviderObservations{
 					payloadRetrievals: map[string]struct{}{},
 				},
 				behavior: &testPayloadProviderBehavior{
 					returnErrorUponPayloadRetrieval: false,
-					payloadsToReturn: map[string]*string{
-						actorName: payload,
+					payloadsToReturn: map[string]*loadsupport.PayloadWrapper{
+						actorName: pw,
 					},
 				},
 			}
@@ -737,7 +736,7 @@ func TestLoadRunner_getOrAssemblePayload(t *testing.T) {
 			}
 
 			msg = "\t\treturned payload must match the one given in test payload provider"
-			if p == payload {
+			if p == pw {
 				t.Log(msg, checkMark)
 			} else {
 				t.Fatal(msg, ballotX)

--- a/maps/loadrunner_test.go
+++ b/maps/loadrunner_test.go
@@ -7,7 +7,6 @@ import (
 	"hazeltest/hazelcastwrapper"
 	"hazeltest/loadsupport"
 	"hazeltest/status"
-	"strconv"
 	"testing"
 )
 
@@ -459,30 +458,21 @@ func TestLoadRunner_runMapTests(t *testing.T) {
 				t.Fatal(msg, ballotX, l.observations.numInitLooperInvocations)
 			}
 
-			msg = "\t\tnumber of generated load elements must be correct"
-			elements := l.assignedTestLoopExecution.elements
-			if len(elements) == numEntriesPerMap {
+			// Unlike the Pokedex Runner, the Load Runner does not rely on
+			// pre-initialized load elements, so the elements slice in the
+			// assigned test loop execution must be empty.
+			msg = "\t\tnumber of generated load elements must be zero"
+			if len(l.assignedTestLoopExecution.elements) == 0 {
 				t.Log(msg, checkMark)
 			} else {
-				t.Fatal(msg, ballotX, len(elements))
+				t.Fatal(msg, ballotX, len(l.assignedTestLoopExecution.elements))
 			}
 
-			msg = "\t\tkeys must have been populated on load elements"
-			for i, v := range elements {
-				if v.Key == strconv.Itoa(i) {
-					t.Log(msg, checkMark, v.Key)
-				} else {
-					t.Fatal(msg, ballotX, v.Key)
-				}
-			}
-
-			msg = "\t\tall load elements must carry nil Payload"
-			for _, v := range elements {
-				if v.Payload == nil {
-					t.Log(msg, checkMark, v.Key)
-				} else {
-					t.Fatal(msg, ballotX, v.Key, v.Payload)
-				}
+			msg = "\t\tconfig must have been correctly populated with number of map elements"
+			if l.assignedTestLoopExecution.runnerConfig.numEntriesPerMap == uint32(numEntriesPerMap) {
+				t.Log(msg, checkMark)
+			} else {
+				t.Fatal(msg, ballotX)
 			}
 
 			msg = "\t\trequirement for generation of fixed-size payload must have been registered"
@@ -577,7 +567,7 @@ func TestLoadRunner_runMapTests(t *testing.T) {
 				t.Fatal(msg, ballotX)
 			}
 
-			msg = "˜\t\tregistered requirement must be correct"
+			msg = "\t\tregistered requirement must be correct"
 			if !registeredForActor.UseFixedSize &&
 				registeredForActor.UseVariableSize &&
 				registeredForActor.VariableSize.SameSizeStepsLimit == variablePayloadEvaluateNewSizeAfterNumWriteActions &&
@@ -595,21 +585,14 @@ func TestLoadRunner_runMapTests(t *testing.T) {
 				t.Fatal(msg, ballotX, l.observations.numInitLooperInvocations)
 			}
 
-			msg = "\t\tnumber of generated load elements must be correct"
-			elements := l.assignedTestLoopExecution.elements
-			if len(elements) == numEntriesPerMap {
+			// The Load Runner does not make use of pre-initialized load elements regardless of
+			// the configured payload mode, so make sure load elements slice is empty in case
+			// of variable-size payloads, too
+			msg = "\t\tnumber of generated load elements must be zero"
+			if len(l.assignedTestLoopExecution.elements) == 0 {
 				t.Log(msg, checkMark)
 			} else {
-				t.Fatal(msg, ballotX, len(elements))
-			}
-
-			msg = "\t\tonly keys of load elements must have been populated"
-			for i, v := range elements {
-				if v.Key == strconv.Itoa(i) && v.Payload == nil {
-					t.Log(msg, checkMark, v.Key)
-				} else {
-					t.Fatal(msg, ballotX, v.Key)
-				}
+				t.Fatal(msg, ballotX, len(l.assignedTestLoopExecution.elements))
 			}
 
 			msg = "\t\ttest loop must have been run once"

--- a/maps/loadrunner_test.go
+++ b/maps/loadrunner_test.go
@@ -255,7 +255,7 @@ func TestLoadRunner_runMapTests(t *testing.T) {
 				t.Fatal(msg, ballotX, ch.shutdownInvocations)
 			}
 		}
-		t.Log("\twhen test loop has executed")
+		t.Log("\twhen test loop was executed")
 		{
 			assigner := testConfigPropertyAssigner{
 				returnError: false,
@@ -270,7 +270,11 @@ func TestLoadRunner_runMapTests(t *testing.T) {
 			ch := &testHzClientHandler{}
 			ms := &testHzMapStore{observations: &testHzMapStoreObservations{}}
 			l := newTestLoadTestLoop()
-
+			tp := &testPayloadProvider{
+				observations: &testPayloadProviderObservations{
+					requirementRegistrations: map[string]loadsupport.PayloadGenerationRequirement{},
+				},
+			}
 			r := loadRunner{
 				assigner:        assigner,
 				stateList:       []runnerState{},
@@ -284,7 +288,9 @@ func TestLoadRunner_runMapTests(t *testing.T) {
 						l.observations.numNewLooperInvocations++
 						return l, nil
 					},
-					payloads: nil,
+					payloads: func() loadsupport.PayloadProvider {
+						return tp
+					},
 				},
 			}
 
@@ -358,6 +364,20 @@ func TestLoadRunner_runMapTests(t *testing.T) {
 				t.Fatal(msg, ballotX)
 			}
 
+			msg = "\t\tgeneration requirement for variable-size payloads must have been correctly registered"
+			registeredRequirements := tp.observations.requirementRegistrations
+			registeredForActor, ok := registeredRequirements[mapLoadRunnerName]
+			if len(registeredRequirements) == 1 && ok &&
+				!registeredForActor.UseFixedSize &&
+				registeredForActor.UseVariableSize &&
+				registeredForActor.VariableSize.SameSizeStepsLimit == variablePayloadEvaluateNewSizeAfterNumWriteActions &&
+				registeredForActor.VariableSize.LowerBoundaryBytes == variablePayloadSizeLowerBoundaryBytes &&
+				registeredForActor.VariableSize.UpperBoundaryBytes == variablePayloadSizeUpperBoundaryBytes {
+				t.Log(msg, checkMark)
+			} else {
+				t.Fatal(msg, ballotX)
+			}
+
 		}
 		t.Log("\twhen test loop cannot be initialized")
 		{
@@ -420,7 +440,9 @@ func TestLoadRunner_runMapTests(t *testing.T) {
 			ch := &testHzClientHandler{}
 			l := newTestLoadTestLoop()
 			tp := &testPayloadProvider{
-				observations: &testPayloadProviderObservations{},
+				observations: &testPayloadProviderObservations{
+					requirementRegistrations: map[string]loadsupport.PayloadGenerationRequirement{},
+				},
 			}
 			r := loadRunner{
 				assigner:        a,
@@ -533,7 +555,9 @@ func TestLoadRunner_runMapTests(t *testing.T) {
 			ch := &testHzClientHandler{}
 			l := newTestLoadTestLoop()
 			tp := &testPayloadProvider{
-				observations: &testPayloadProviderObservations{},
+				observations: &testPayloadProviderObservations{
+					requirementRegistrations: map[string]loadsupport.PayloadGenerationRequirement{},
+				},
 			}
 			r := loadRunner{
 				assigner:        a,
@@ -632,7 +656,9 @@ func TestLoadRunner_runMapTests(t *testing.T) {
 			ch := &testHzClientHandler{}
 			l := newTestLoadTestLoop()
 			tp := &testPayloadProvider{
-				observations: &testPayloadProviderObservations{},
+				observations: &testPayloadProviderObservations{
+					requirementRegistrations: map[string]loadsupport.PayloadGenerationRequirement{},
+				},
 			}
 			r := loadRunner{
 				assigner:        a,

--- a/maps/loadrunner_test.go
+++ b/maps/loadrunner_test.go
@@ -53,7 +53,7 @@ func TestPopulateLoadElementKeys(t *testing.T) {
 				}
 
 				for _, l := range loadElementOnlyKeys {
-					if l.Payload == "" {
+					if l.Payload == nil {
 						t.Log(msgEmptyPayload, checkMark, l.Key, numKeys)
 					} else {
 						t.Fatal(msgEmptyPayload, ballotX, l.Key, numKeys)
@@ -83,7 +83,7 @@ func TestPopulateLoadElements(t *testing.T) {
 				}
 
 				for _, l := range loadElements {
-					if len(l.Payload) == payloadSize {
+					if len(*l.Payload) == payloadSize {
 						t.Log(msgPayloadSize, checkMark, numEntries, payloadSize)
 					} else {
 						t.Fatal(msgPayloadSize, ballotX, numEntries, payloadSize)
@@ -469,7 +469,7 @@ func TestRunLoadMapTests(t *testing.T) {
 
 			msg = "\t\tboth key and payload must have been populated on each generated load element"
 			for i, v := range elements {
-				if v.Key == strconv.Itoa(i) && len(v.Payload) == fixedPayloadSizeBytes {
+				if v.Key == strconv.Itoa(i) && len(*v.Payload) == fixedPayloadSizeBytes {
 					t.Log(msg, checkMark, v.Key)
 				} else {
 					t.Fatal(msg, ballotX, v.Key)
@@ -585,7 +585,7 @@ func TestRunLoadMapTests(t *testing.T) {
 
 			msg = "\t\tonly keys of load elements must have been populated"
 			for i, v := range elements {
-				if v.Key == strconv.Itoa(i) && v.Payload == "" {
+				if v.Key == strconv.Itoa(i) && v.Payload == nil {
 					t.Log(msg, checkMark, v.Key)
 				} else {
 					t.Fatal(msg, ballotX, v.Key)
@@ -721,9 +721,10 @@ func TestGetOrAssemblePayload(t *testing.T) {
 			{
 				useFixedPayload = true
 
+				s := "awesome-value"
 				le := loadElement{
 					Key:     "awesome-key",
-					Payload: "awesome-value",
+					Payload: &s,
 				}
 				p, err := getOrAssemblePayload("awesome-map-name", uint16(0), le)
 

--- a/maps/loadrunner_test.go
+++ b/maps/loadrunner_test.go
@@ -700,7 +700,7 @@ func TestGetOrAssemblePayload(t *testing.T) {
 
 				le := loadElement{}
 
-				v, err := getOrAssemblePayload("some-map-name", uint16(0), le)
+				p, err := getOrAssemblePayload("some-map-name", uint16(0), le)
 
 				msg := "\t\terror must be returned"
 				if err != nil {
@@ -709,9 +709,8 @@ func TestGetOrAssemblePayload(t *testing.T) {
 					t.Fatal(msg, ballotX)
 				}
 
-				payload := v.(string)
-				msg = "\t\tempty payload must be returned"
-				if len(payload) == 0 {
+				msg = "\t\tempty payload pointer must be returned"
+				if p == nil {
 					t.Log(msg, checkMark)
 				} else {
 					t.Fatal(msg, ballotX)
@@ -753,7 +752,7 @@ func TestGetOrAssemblePayload(t *testing.T) {
 			{
 				loadsupport.ActorTracker = loadsupport.PayloadConsumingActorTracker{}
 
-				v, err := getOrAssemblePayload("map-name", uint16(6), loadElement{})
+				p, err := getOrAssemblePayload("map-name", uint16(6), loadElement{})
 
 				msg := "\t\terror must be returned"
 				if err != nil {
@@ -762,9 +761,8 @@ func TestGetOrAssemblePayload(t *testing.T) {
 					t.Fatal(msg, ballotX)
 				}
 
-				payload := v.(string)
-				msg = "\t\tempty payload must be returned"
-				if len(payload) == 0 {
+				msg = "\t\tempty payload pointer must be returned"
+				if p == nil {
 					t.Log(msg, checkMark)
 				} else {
 					t.Fatal(msg, ballotX)
@@ -787,7 +785,7 @@ func TestGetOrAssemblePayload(t *testing.T) {
 					SameSizeStepsLimit: variablePayloadEvaluateNewSizeAfterNumWriteActions,
 				})
 
-				v, err := getOrAssemblePayload("ht_load", uint16(0), loadElement{})
+				p, err := getOrAssemblePayload("ht_load", uint16(0), loadElement{})
 
 				msg := "\t\t\tno error must be returned"
 				if err == nil {
@@ -796,7 +794,7 @@ func TestGetOrAssemblePayload(t *testing.T) {
 					t.Fatal(msg, ballotX, err)
 				}
 
-				payload := v.(string)
+				payload := *p
 				msg = "\t\t\tpayload must be generated within the specified boundaries"
 				if len(payload) >= variablePayloadSizeLowerBoundaryBytes && len(payload) <= variablePayloadSizeUpperBoundaryBytes {
 					t.Log(msg, checkMark)
@@ -810,7 +808,7 @@ func TestGetOrAssemblePayload(t *testing.T) {
 			useFixedPayload = false
 			useVariablePayload = false
 
-			v, err := getOrAssemblePayload("some-map-name", uint16(0), loadElement{})
+			p, err := getOrAssemblePayload("some-map-name", uint16(0), loadElement{})
 
 			msg := "\t\terror must be returned"
 			if err != nil {
@@ -819,9 +817,8 @@ func TestGetOrAssemblePayload(t *testing.T) {
 				t.Fatal(msg, ballotX)
 			}
 
-			payload := v.(string)
-			msg = "\t\tempty payload must be returned"
-			if len(payload) == 0 {
+			msg = "\t\tempty payload pointer must be returned"
+			if p == nil {
 				t.Log(msg, checkMark)
 			} else {
 				t.Fatal(msg, ballotX)
@@ -832,7 +829,7 @@ func TestGetOrAssemblePayload(t *testing.T) {
 			useFixedPayload = true
 			useVariablePayload = true
 
-			v, err := getOrAssemblePayload("some-map-name", uint16(0), loadElement{})
+			p, err := getOrAssemblePayload("some-map-name", uint16(0), loadElement{})
 
 			msg := "\t\terror must be returned"
 			if err != nil {
@@ -841,9 +838,8 @@ func TestGetOrAssemblePayload(t *testing.T) {
 				t.Fatal(msg, ballotX)
 			}
 
-			payload := v.(string)
-			msg = "\t\tempty payload must be returned"
-			if len(payload) == 0 {
+			msg = "\t\tempty payload pointer must be returned"
+			if p == nil {
 				t.Log(msg, checkMark)
 			} else {
 				t.Fatal(msg, ballotX)

--- a/maps/loadrunner_test.go
+++ b/maps/loadrunner_test.go
@@ -468,13 +468,29 @@ func TestRunLoadMapTests(t *testing.T) {
 				t.Fatal(msg, ballotX, len(elements))
 			}
 
-			msg = "\t\tboth key and payload must have been populated on each generated load element"
+			msg = "\t\tkeys must have been populated on load elements"
 			for i, v := range elements {
-				if v.Key == strconv.Itoa(i) && len(*v.Payload) == fixedPayloadSizeBytes {
+				if v.Key == strconv.Itoa(i) {
 					t.Log(msg, checkMark, v.Key)
 				} else {
 					t.Fatal(msg, ballotX, v.Key)
 				}
+			}
+
+			msg = "\t\tall load elements must carry nil Payload"
+			for _, v := range elements {
+				if v.Payload == nil {
+					t.Log(msg, checkMark, v.Key)
+				} else {
+					t.Fatal(msg, ballotX, v.Key, v.Payload)
+				}
+			}
+
+			msg = "\t\tfixed-size payload must have been initialized"
+			if p, err := loadsupport.RetrieveInitializedFixedSizePayload(mapLoadRunnerName); err == nil && len(*p) == fixedPayloadSizeBytes {
+				t.Log(msg, checkMark)
+			} else {
+				t.Fatal(msg, ballotX)
 			}
 
 			msg = "\t\ttest loop must have been run once"
@@ -484,15 +500,15 @@ func TestRunLoadMapTests(t *testing.T) {
 				t.Fatal(msg, ballotX, l.observations.numRunInvocations)
 			}
 
-			pgr, err := loadsupport.ActorTracker.FindMatchingPayloadGenerationRequirement(r.name)
-			msg = "\t\tno payload generation requirement must have been registered, so error must be returned upon attempt to find a matching one"
+			pgr, err := loadsupport.ActorTracker.FindMatchingVariableSizePayloadGenerationRequirement(r.name)
+			msg = "\t\tno variable-size payload generation requirement must have been registered, so error must be returned upon attempt to find a matching one"
 			if err != nil {
 				t.Log(msg, checkMark)
 			} else {
 				t.Fatal(msg, ballotX)
 			}
 
-			msg = "\t\tempty payload generation requirement must be returned"
+			msg = "\t\tempty variable-size payload generation requirement must have been returned"
 			emptyPgr := loadsupport.VariablePayloadGenerationRequirement{}
 			if pgr == emptyPgr {
 				t.Log(msg, checkMark)
@@ -551,7 +567,7 @@ func TestRunLoadMapTests(t *testing.T) {
 				t.Fatal(msg, ballotX, l.observations.numNewLooperInvocations)
 			}
 
-			registeredRequirement, err := loadsupport.ActorTracker.FindMatchingPayloadGenerationRequirement(r.name)
+			registeredRequirement, err := loadsupport.ActorTracker.FindMatchingVariableSizePayloadGenerationRequirement(r.name)
 
 			msg = "\t\tno error must be returned upon attempt to find matching payload generation requirement"
 			if err == nil {
@@ -669,7 +685,7 @@ func TestRunLoadMapTests(t *testing.T) {
 				t.Fatal(msg, ballotX, detail)
 			}
 
-			pgr, err := loadsupport.ActorTracker.FindMatchingPayloadGenerationRequirement(r.name)
+			pgr, err := loadsupport.ActorTracker.FindMatchingVariableSizePayloadGenerationRequirement(r.name)
 			msg = "\t\tno payload generation requirement must have been registered, so error must be returned upon attempt to find a matching one"
 			if err != nil {
 				t.Log(msg, checkMark)

--- a/maps/pokedexrunner.go
+++ b/maps/pokedexrunner.go
@@ -147,17 +147,18 @@ func (r *pokedexRunner) runMapTests(ctx context.Context, hzCluster string, hzMem
 	lp.LogMapRunnerEvent("starting pokedex test loop for maps", r.name, log.InfoLevel)
 
 	le := &testLoopExecution[pokemon]{
-		id:                   uuid.New(),
-		runnerName:           r.name,
-		source:               r.source,
-		hzClientHandler:      r.hzClientHandler,
-		hzMapStore:           r.hzMapStore,
-		stateCleanerBuilder:  &state.DefaultSingleMapCleanerBuilder{},
-		runnerConfig:         config,
-		elements:             pd.Pokemon,
-		ctx:                  ctx,
-		getElementID:         getPokemonID,
-		getOrAssemblePayload: returnPokemonPayload,
+		id:                        uuid.New(),
+		runnerName:                r.name,
+		source:                    r.source,
+		hzClientHandler:           r.hzClientHandler,
+		hzMapStore:                r.hzMapStore,
+		stateCleanerBuilder:       &state.DefaultSingleMapCleanerBuilder{},
+		runnerConfig:              config,
+		elements:                  pd.Pokemon,
+		usePreInitializedElements: true,
+		ctx:                       ctx,
+		getElementID:              getPokemonID,
+		getOrAssemblePayload:      returnPokemonPayload,
 	}
 
 	r.l.init(le, &defaultSleeper{}, r.gatherer)

--- a/maps/pokedexrunner.go
+++ b/maps/pokedexrunner.go
@@ -3,7 +3,6 @@ package maps
 import (
 	"context"
 	"embed"
-	"encoding/gob"
 	"encoding/json"
 	"fmt"
 	"github.com/google/uuid"
@@ -75,7 +74,6 @@ func init() {
 			pokemonTestLoop newPokemonTestLoopFunc
 		}{mapStore: newDefaultMapStore, pokemonTestLoop: initPokedexTestLoop},
 	})
-	gob.Register(pokemon{})
 }
 
 func initPokedexTestLoop(rc *runnerConfig) (looper[pokemon], error) {

--- a/maps/pokedexrunner.go
+++ b/maps/pokedexrunner.go
@@ -182,11 +182,12 @@ func returnPokemonPayload(_ string, _ uint16, elementID string) (*string, error)
 		return nil, fmt.Errorf("unable to find pokemon with ID '%s' in given pokedex", elementID)
 	}
 
+	if p == nil {
+		return nil, fmt.Errorf("pokemon with ID '%s' was associated with nil entry in given pokedex", elementID)
+	}
+
 	pJson, err := json.Marshal(p)
 	if err != nil {
-		// Effectively can't happen -- once we've made sure
-		// the given element is a pokemon, the marshal operation
-		// must be successful. But keep check in place just in case...
 		return nil, err
 	}
 	pString := string(pJson)

--- a/maps/pokedexrunner.go
+++ b/maps/pokedexrunner.go
@@ -173,14 +173,21 @@ func (r *pokedexRunner) appendState(s runnerState) {
 
 }
 
-func returnPokemonPayload(_ string, _ uint16, element any) (any, error) {
-	return element, nil
+func returnPokemonPayload(_ string, _ uint16, element any) (*string, error) {
+
+	// TODO Update tests
+	pJson, err := json.Marshal(element)
+	if err != nil {
+		return nil, err
+	}
+	pString := string(pJson)
+	return &pString, nil
 }
 
 func getPokemonID(element any) string {
 
-	pokemon := element.(pokemon)
-	return fmt.Sprintf("%d", pokemon.ID)
+	p := element.(pokemon)
+	return fmt.Sprintf("%d", p.ID)
 
 }
 

--- a/maps/pokedexrunner.go
+++ b/maps/pokedexrunner.go
@@ -122,6 +122,8 @@ func (r *pokedexRunner) runMapTests(ctx context.Context, hzCluster string, hzMem
 	}
 
 	initializePokemonElements(pd)
+	// TODO In tests, verify property gets set
+	config.numEntriesPerMap = uint32(len(pokemonEntries))
 
 	l, err := r.providerFuncs.pokemonTestLoop(config)
 	if err != nil {

--- a/maps/pokedexrunner.go
+++ b/maps/pokedexrunner.go
@@ -175,9 +175,15 @@ func (r *pokedexRunner) appendState(s runnerState) {
 
 func returnPokemonPayload(_ string, _ uint16, element any) (*string, error) {
 
-	// TODO Update tests
+	if _, ok := element.(pokemon); !ok {
+		return nil, fmt.Errorf("given element is not a pokemon: %v", element)
+	}
+
 	pJson, err := json.Marshal(element)
 	if err != nil {
+		// Effectively can't happen -- once we've made sure
+		// the given element is a pokemon, the marshal operation
+		// must be successful. But keep check in place just in case...
 		return nil, err
 	}
 	pString := string(pJson)

--- a/maps/pokedexrunner.go
+++ b/maps/pokedexrunner.go
@@ -10,6 +10,7 @@ import (
 	"hazeltest/api"
 	"hazeltest/client"
 	"hazeltest/hazelcastwrapper"
+	"hazeltest/loadsupport"
 	"hazeltest/state"
 	"hazeltest/status"
 	"strconv"
@@ -178,7 +179,7 @@ func (r *pokedexRunner) appendState(s runnerState) {
 
 }
 
-func returnPokemonPayload(_ string, _ uint16, elementID string) (*string, error) {
+func returnPokemonPayload(_ string, _ uint16, elementID string) (*loadsupport.PayloadWrapper, error) {
 
 	p, ok := pokemonEntries[elementID]
 	if !ok {
@@ -193,8 +194,7 @@ func returnPokemonPayload(_ string, _ uint16, elementID string) (*string, error)
 	if err != nil {
 		return nil, err
 	}
-	pString := string(pJson)
-	return &pString, nil
+	return &loadsupport.PayloadWrapper{Payload: pJson}, nil
 }
 
 func getPokemonID(element any) string {

--- a/maps/pokedexrunner_test.go
+++ b/maps/pokedexrunner_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"hazeltest/hazelcastwrapper"
 	"hazeltest/status"
+	"strconv"
 	"testing"
 )
 
@@ -25,18 +26,20 @@ func TestReturnPokemonPayload(t *testing.T) {
 		t.Log("\twhen given element is not a pokemon")
 		{
 			digimon := struct {
+				id                            int
 				digimonsProbablyAlsoHaveAName string
 				andPerhapsAColor              string
 				andAnAge                      int
 				andMaybeAWeight               int
 			}{
+				42,
 				"Dave-imon",
 				"orange",
 				153,
 				21,
 			}
 
-			sp, err := returnPokemonPayload("", 0, digimon)
+			sp, err := returnPokemonPayload("", 0, strconv.Itoa(digimon.id))
 
 			msg := "\t\terror must be returned"
 			if err != nil {
@@ -52,54 +55,81 @@ func TestReturnPokemonPayload(t *testing.T) {
 				t.Fatal(msg, ballotX)
 			}
 		}
-		t.Log("\twhen given element is pokemon")
+		t.Log("\twhen pokedex entries map contains given pokemon id")
 		{
-			pokemonElement := pokemon{
-				ID:          1,
-				Num:         "001",
-				Name:        "Bulbasaur",
-				Img:         "bulbasaur.png",
-				ElementType: []string{"Grass", "Poison"},
-				Height:      "0.71 m",
-				Weight:      "6.9 kg",
-				Candy:       "Bulbasaur Candy",
-				CandyCount:  25,
-				EggDistance: "2 km",
-				SpawnChance: 0.69,
-				AvgSpawns:   69.0,
-				SpawnTime:   "20:00",
-				Multipliers: []float32{1.58},
-				Weaknesses:  []string{"Fire", "Ice", "Flying", "Psychic"},
-				NextEvolution: []nextEvolution{
-					{Num: "002", Name: "Ivysaur"},
-					{Num: "003", Name: "Venusaur"},
-				},
+			t.Log("\t\twhen pokemon id points to non-nil pokemon entry")
+			{
+				pokemonElement := pokemon{
+					ID:          1,
+					Num:         "001",
+					Name:        "Bulbasaur",
+					Img:         "bulbasaur.png",
+					ElementType: []string{"Grass", "Poison"},
+					Height:      "0.71 m",
+					Weight:      "6.9 kg",
+					Candy:       "Bulbasaur Candy",
+					CandyCount:  25,
+					EggDistance: "2 km",
+					SpawnChance: 0.69,
+					AvgSpawns:   69.0,
+					SpawnTime:   "20:00",
+					Multipliers: []float32{1.58},
+					Weaknesses:  []string{"Fire", "Ice", "Flying", "Psychic"},
+					NextEvolution: []nextEvolution{
+						{Num: "002", Name: "Ivysaur"},
+						{Num: "003", Name: "Venusaur"},
+					},
+				}
+				pokemonEntries[strconv.Itoa(pokemonElement.ID)] = &pokemonElement
+
+				sp, err := returnPokemonPayload("", 0, strconv.Itoa(pokemonElement.ID))
+
+				msg := "\t\t\tno error must be returned"
+				if err == nil {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX)
+				}
+
+				unmarshalledPokemonElement := &pokemon{}
+				err = json.Unmarshal([]byte(*sp), unmarshalledPokemonElement)
+
+				msg = "\t\t\tno error must be returned upon attempt to unmarshal pokemon"
+				if err == nil {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX)
+				}
+
+				msg = "\t\t\tpointer to string representation of pokemon must be returned"
+				if unmarshalledPokemonElement.ID == pokemonElement.ID {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX)
+				}
+
 			}
+			t.Log("\t\twhen pokemon id points to nil entry")
+			{
+				pokemonID := "42"
 
-			sp, err := returnPokemonPayload("", 0, pokemonElement)
+				pokemonEntries[pokemonID] = nil
 
-			msg := "\t\tno error must be returned"
-			if err == nil {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX)
-			}
+				sp, err := returnPokemonPayload("", uint16(9), pokemonID)
 
-			unmarshalledPokemonElement := &pokemon{}
-			err = json.Unmarshal([]byte(*sp), unmarshalledPokemonElement)
+				msg := "\t\t\terror must be returned"
+				if err != nil {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX)
+				}
 
-			msg = "\t\tno error must be returned upon attempt to unmarshal pokemon"
-			if err == nil {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX)
-			}
-
-			msg = "\t\tpointer to string representation of pokemon must be returned"
-			if unmarshalledPokemonElement.ID == pokemonElement.ID {
-				t.Log(msg, checkMark)
-			} else {
-				t.Fatal(msg, ballotX)
+				msg = "\t\t\tnil pointer must be returned"
+				if sp == nil {
+					t.Log(msg, checkMark)
+				} else {
+					t.Fatal(msg, ballotX)
+				}
 			}
 		}
 	}

--- a/maps/pokedexrunner_test.go
+++ b/maps/pokedexrunner_test.go
@@ -2,6 +2,7 @@ package maps
 
 import (
 	"context"
+	"encoding/json"
 	"hazeltest/hazelcastwrapper"
 	"hazeltest/status"
 	"testing"
@@ -15,6 +16,94 @@ func (d testPokedexTestLoop) init(_ *testLoopExecution[pokemon], _ sleeper, _ st
 
 func (d testPokedexTestLoop) run() {
 	// No-op
+}
+
+func TestReturnPokemonPayload(t *testing.T) {
+
+	t.Log("given a function retrieve the string pointer to an element that might be a pokemon")
+	{
+		t.Log("\twhen given element is not a pokemon")
+		{
+			digimon := struct {
+				digimonsProbablyAlsoHaveAName string
+				andPerhapsAColor              string
+				andAnAge                      int
+				andMaybeAWeight               int
+			}{
+				"Dave-imon",
+				"orange",
+				153,
+				21,
+			}
+
+			sp, err := returnPokemonPayload("", 0, digimon)
+
+			msg := "\t\terror must be returned"
+			if err != nil {
+				t.Log(msg, checkMark)
+			} else {
+				t.Fatal(msg, ballotX)
+			}
+
+			msg = "\t\tnil pointer must be returned"
+			if sp == nil {
+				t.Log(msg, checkMark)
+			} else {
+				t.Fatal(msg, ballotX)
+			}
+		}
+		t.Log("\twhen given element is pokemon")
+		{
+			pokemonElement := pokemon{
+				ID:          1,
+				Num:         "001",
+				Name:        "Bulbasaur",
+				Img:         "bulbasaur.png",
+				ElementType: []string{"Grass", "Poison"},
+				Height:      "0.71 m",
+				Weight:      "6.9 kg",
+				Candy:       "Bulbasaur Candy",
+				CandyCount:  25,
+				EggDistance: "2 km",
+				SpawnChance: 0.69,
+				AvgSpawns:   69.0,
+				SpawnTime:   "20:00",
+				Multipliers: []float32{1.58},
+				Weaknesses:  []string{"Fire", "Ice", "Flying", "Psychic"},
+				NextEvolution: []nextEvolution{
+					{Num: "002", Name: "Ivysaur"},
+					{Num: "003", Name: "Venusaur"},
+				},
+			}
+
+			sp, err := returnPokemonPayload("", 0, pokemonElement)
+
+			msg := "\t\tno error must be returned"
+			if err == nil {
+				t.Log(msg, checkMark)
+			} else {
+				t.Fatal(msg, ballotX)
+			}
+
+			unmarshalledPokemonElement := &pokemon{}
+			err = json.Unmarshal([]byte(*sp), unmarshalledPokemonElement)
+
+			msg = "\t\tno error must be returned upon attempt to unmarshal pokemon"
+			if err == nil {
+				t.Log(msg, checkMark)
+			} else {
+				t.Fatal(msg, ballotX)
+			}
+
+			msg = "\t\tpointer to string representation of pokemon must be returned"
+			if unmarshalledPokemonElement.ID == pokemonElement.ID {
+				t.Log(msg, checkMark)
+			} else {
+				t.Fatal(msg, ballotX)
+			}
+		}
+	}
+
 }
 
 func TestInitializePokemonTestLoop(t *testing.T) {

--- a/maps/pokedexrunner_test.go
+++ b/maps/pokedexrunner_test.go
@@ -82,7 +82,7 @@ func TestReturnPokemonPayload(t *testing.T) {
 				}
 				pokemonEntries[strconv.Itoa(pokemonElement.ID)] = &pokemonElement
 
-				sp, err := returnPokemonPayload("", 0, strconv.Itoa(pokemonElement.ID))
+				pw, err := returnPokemonPayload("", 0, strconv.Itoa(pokemonElement.ID))
 
 				msg := "\t\t\tno error must be returned"
 				if err == nil {
@@ -92,7 +92,7 @@ func TestReturnPokemonPayload(t *testing.T) {
 				}
 
 				unmarshalledPokemonElement := &pokemon{}
-				err = json.Unmarshal([]byte(*sp), unmarshalledPokemonElement)
+				err = json.Unmarshal(pw.Payload, unmarshalledPokemonElement)
 
 				msg = "\t\t\tno error must be returned upon attempt to unmarshal pokemon"
 				if err == nil {

--- a/maps/runner.go
+++ b/maps/runner.go
@@ -23,6 +23,7 @@ type (
 		enabled                 bool
 		numMaps                 uint16
 		numRuns                 uint32
+		numEntriesPerMap        uint32
 		mapBaseName             string
 		useMapPrefix            bool
 		mapPrefix               string

--- a/maps/testloop.go
+++ b/maps/testloop.go
@@ -21,7 +21,7 @@ import (
 type (
 	evaluateTimeToSleep      func(sc *sleepConfig) int
 	getElementIdFunc         func(element any) string
-	getOrAssemblePayloadFunc func(mapName string, mapNumber uint16, element any) (any, error)
+	getOrAssemblePayloadFunc func(mapName string, mapNumber uint16, element any) (*string, error)
 	looper[t any]            interface {
 		init(lc *testLoopExecution[t], s sleeper, gatherer status.Gatherer)
 		run()
@@ -407,7 +407,7 @@ func (l *boundaryTestLoop[t]) executeMapAction(m hazelcastwrapper.Map, mapName s
 			lp.LogMapRunnerEvent(fmt.Sprintf("unable to execute insert operation for map '%s' due to error upon generating payload: %v", mapName, err), l.tle.runnerName, log.ErrorLevel)
 			return err
 		}
-		if err := m.Set(l.tle.ctx, key, payload); err != nil {
+		if err := m.Set(l.tle.ctx, key, toValue(payload)); err != nil {
 			l.ct.increaseCounter(statusKeyNumFailedInserts)
 			lp.LogHzEvent(fmt.Sprintf("failed to insert key '%s' into map '%s'", key, mapName), log.WarnLevel)
 			return err
@@ -671,7 +671,7 @@ func (l *batchTestLoop[t]) ingestAll(m hazelcastwrapper.Map, mapName string, map
 		if err != nil {
 			return err
 		}
-		if err = m.Set(l.tle.ctx, key, value); err != nil {
+		if err = m.Set(l.tle.ctx, key, toValue(value)); err != nil {
 			l.ct.increaseCounter(statusKeyNumFailedInserts)
 			return err
 		}
@@ -769,4 +769,18 @@ func assembleMapKey(mapName string, mapNumber uint16, elementID string) string {
 
 	return fmt.Sprintf("%s-%s-%d-%s", client.ID(), mapName, mapNumber, elementID)
 
+}
+
+/*
+	toValue simply dereferences the given pointer and returns the string value.
+
+We need to make sure to dereference strings and pass their values into Hazelcast due to auto-registering of
+values to be serialized using gob.Register that happens in Hazelcast Golang client as of version 1.4.2.
+At this point in code execution, multiple values have already been sent to the target Hazelcast cluster,
+having gone through serialization -- hence through auto-registration --, and since these values are strings,
+the string type has already been registered. Trying to pass in a string pointer now yields the
+'gob: registering duplicate names for *string: "string" != "*string' error message.
+*/
+func toValue(s *string) string {
+	return *s
 }

--- a/maps/testloop.go
+++ b/maps/testloop.go
@@ -328,8 +328,6 @@ func (l *boundaryTestLoop[t]) runOperationChain(
 	availableElements *availableElementsWrapper,
 ) error {
 
-	useLocalKeysCache := len(availableElements.pool) > 0
-
 	chainLength := uint32(l.tle.runnerConfig.boundary.chainLength)
 
 	lp.LogMapRunnerEvent(fmt.Sprintf("starting operation chain of length %d for map '%s' on goroutine %d", chainLength, mapName, mapNumber), l.tle.runnerName, log.InfoLevel)
@@ -365,7 +363,7 @@ func (l *boundaryTestLoop[t]) runOperationChain(
 
 		var nextMapElementKey string
 		var err error
-		if useLocalKeysCache {
+		if l.tle.usePreInitializedElements {
 			nextMapElementKey, err = l.chooseNextMapElementKey(actions.next, elementsInserted, availableElements.pool)
 		} else {
 			nextMapElementKey, err = evaluateNextMapElementIndex(l.tle.runnerName, actions.next, index.current)
@@ -386,7 +384,7 @@ func (l *boundaryTestLoop[t]) runOperationChain(
 			lp.LogMapRunnerEvent(fmt.Sprintf("encountered error upon execution of '%s' action on map '%s' in run '%d' (still moving to next loop iteration): %v", actions.last, mapName, currentRun, err), l.tle.runnerName, log.WarnLevel)
 		} else {
 			lp.LogMapRunnerEvent(fmt.Sprintf("action '%s' successfully executed on map '%s', moving to next action in upcoming loop iteration", actions.last, mapName), l.tle.runnerName, log.TraceLevel)
-			if useLocalKeysCache {
+			if l.tle.usePreInitializedElements {
 				updateKeysCache(nextMapElementKey, actions.last, elementsInserted, availableElements.pool, l.tle.runnerName)
 			}
 			if actions.last == insert {

--- a/maps/testloop.go
+++ b/maps/testloop.go
@@ -838,6 +838,7 @@ func (l *batchTestLoop[t]) performSingleRemove(m hazelcastwrapper.Map, elementID
 	key := assembleMapKey(mapName, mapNumber, elementID)
 	containsKey, err := m.ContainsKey(l.tle.ctx, key)
 	if err != nil {
+		l.ct.increaseCounter(statusKeyNumFailedKeyChecks)
 		return err
 	}
 	if !containsKey {

--- a/maps/testloop_test.go
+++ b/maps/testloop_test.go
@@ -559,7 +559,7 @@ func TestRunWrapper(t *testing.T) {
 				sleepConfigDisabled,
 			)
 			ms := assembleTestMapStore(&testMapStoreBehavior{})
-			tl := assembleBoundaryTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+			tl := assembleBoundaryTestLoop(uuid.New(), testSource, true, &testHzClientHandler{}, ms, rc)
 			go tl.gatherer.Listen(make(chan struct{}, 1))
 			runWrapper(tl.tle, tl.gatherer, func(config *runnerConfig, u uint16) string {
 				return "banana"
@@ -614,7 +614,7 @@ func TestRunWrapper(t *testing.T) {
 				sleepConfigDisabled,
 			)
 			ms := assembleTestMapStore(&testMapStoreBehavior{})
-			tl := assembleBoundaryTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+			tl := assembleBoundaryTestLoop(uuid.New(), testSource, true, &testHzClientHandler{}, ms, rc)
 
 			cleaner := &testSingleMapCleaner{
 				observations: &testSingleMapCleanerObservations{},
@@ -664,7 +664,7 @@ func TestRunWrapper(t *testing.T) {
 					sleepConfigDisabled,
 				)
 				ms := assembleTestMapStore(&testMapStoreBehavior{})
-				tl := assembleBoundaryTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+				tl := assembleBoundaryTestLoop(uuid.New(), testSource, true, &testHzClientHandler{}, ms, rc)
 
 				cleaner := &testSingleMapCleaner{
 					behavior: &testSingleMapCleanerBehavior{
@@ -716,7 +716,7 @@ func TestRunWrapper(t *testing.T) {
 					sleepConfigDisabled,
 					sleepConfigDisabled)
 				ms := assembleTestMapStore(&testMapStoreBehavior{})
-				tl := assembleBoundaryTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+				tl := assembleBoundaryTestLoop(uuid.New(), testSource, true, &testHzClientHandler{}, ms, rc)
 
 				cleaner := &testSingleMapCleaner{
 					behavior: &testSingleMapCleanerBehavior{
@@ -763,7 +763,7 @@ func TestRunWrapper(t *testing.T) {
 					sleepConfigDisabled,
 				)
 				ms := assembleTestMapStore(&testMapStoreBehavior{})
-				tl := assembleBoundaryTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+				tl := assembleBoundaryTestLoop(uuid.New(), testSource, true, &testHzClientHandler{}, ms, rc)
 
 				cleaner := &testSingleMapCleaner{
 					behavior:     &testSingleMapCleanerBehavior{returnErrorUponClean: true},
@@ -825,7 +825,7 @@ func TestExecuteMapAction(t *testing.T) {
 						42,
 						true,
 					)
-					tl := assembleBoundaryTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+					tl := assembleBoundaryTestLoop(uuid.New(), testSource, true, &testHzClientHandler{}, ms, rc)
 					action := insert
 
 					mapNumber := 0
@@ -901,7 +901,7 @@ func TestExecuteMapAction(t *testing.T) {
 						42,
 						true,
 					)
-					tl := assembleBoundaryTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+					tl := assembleBoundaryTestLoop(uuid.New(), testSource, true, &testHzClientHandler{}, ms, rc)
 
 					go tl.gatherer.Listen(make(chan struct{}, 1))
 					err := tl.executeMapAction(ms.m, "awesome-map-name", 0, theFellowship[0], insert)
@@ -949,7 +949,7 @@ func TestExecuteMapAction(t *testing.T) {
 						42,
 						true,
 					)
-					tl := assembleBoundaryTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+					tl := assembleBoundaryTestLoop(uuid.New(), testSource, true, &testHzClientHandler{}, ms, rc)
 					action := insert
 
 					mapNumber := uint16(0)
@@ -999,7 +999,7 @@ func TestExecuteMapAction(t *testing.T) {
 						42,
 						true,
 					)
-					tl := assembleBoundaryTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+					tl := assembleBoundaryTestLoop(uuid.New(), testSource, true, &testHzClientHandler{}, ms, rc)
 					action := insert
 
 					mapNumber := 0
@@ -1049,7 +1049,7 @@ func TestExecuteMapAction(t *testing.T) {
 						true,
 					)
 					ms := assembleTestMapStore(&testMapStoreBehavior{})
-					tl := assembleBoundaryTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+					tl := assembleBoundaryTestLoop(uuid.New(), testSource, true, &testHzClientHandler{}, ms, rc)
 
 					go tl.gatherer.Listen(make(chan struct{}, 1))
 					err := tl.executeMapAction(ms.m, "my-map-name", uint16(0), theFellowship[0], remove)
@@ -1107,7 +1107,7 @@ func TestExecuteMapAction(t *testing.T) {
 					true,
 				)
 				ms := assembleTestMapStore(&testMapStoreBehavior{returnErrorUponRemove: true})
-				tl := assembleBoundaryTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+				tl := assembleBoundaryTestLoop(uuid.New(), testSource, true, &testHzClientHandler{}, ms, rc)
 
 				populateTestHzMapStore(defaultTestMapName, defaultTestMapNumber, &ms)
 
@@ -1162,7 +1162,7 @@ func TestExecuteMapAction(t *testing.T) {
 					true,
 				)
 				ms := assembleTestMapStore(&testMapStoreBehavior{})
-				tl := assembleBoundaryTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+				tl := assembleBoundaryTestLoop(uuid.New(), testSource, true, &testHzClientHandler{}, ms, rc)
 
 				populateTestHzMapStore(defaultTestMapName, defaultTestMapNumber, &ms)
 
@@ -1206,7 +1206,7 @@ func TestExecuteMapAction(t *testing.T) {
 					true,
 				)
 				ms := assembleTestMapStore(&testMapStoreBehavior{})
-				tl := assembleBoundaryTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+				tl := assembleBoundaryTestLoop(uuid.New(), testSource, true, &testHzClientHandler{}, ms, rc)
 
 				go tl.gatherer.Listen(make(chan struct{}, 1))
 				err := tl.executeMapAction(ms.m, "my-map-name", uint16(0), theFellowship[0], read)
@@ -1257,7 +1257,7 @@ func TestExecuteMapAction(t *testing.T) {
 					true,
 				)
 				ms := assembleTestMapStore(&testMapStoreBehavior{returnErrorUponGet: true})
-				tl := assembleBoundaryTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+				tl := assembleBoundaryTestLoop(uuid.New(), testSource, true, &testHzClientHandler{}, ms, rc)
 
 				populateTestHzMapStore(defaultTestMapName, defaultTestMapNumber, &ms)
 
@@ -1313,7 +1313,7 @@ func TestExecuteMapAction(t *testing.T) {
 						true,
 					)
 					ms := assembleTestMapStore(&testMapStoreBehavior{})
-					tl := assembleBoundaryTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+					tl := assembleBoundaryTestLoop(uuid.New(), testSource, true, &testHzClientHandler{}, ms, rc)
 
 					populateTestHzMapStore(defaultTestMapName, defaultTestMapNumber, &ms)
 
@@ -1363,7 +1363,7 @@ func TestExecuteMapAction(t *testing.T) {
 				true,
 			)
 			ms := assembleTestMapStore(&testMapStoreBehavior{})
-			tl := assembleBoundaryTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+			tl := assembleBoundaryTestLoop(uuid.New(), testSource, true, &testHzClientHandler{}, ms, rc)
 			var unknownAction mapAction = "yeeeehaw"
 
 			err := tl.executeMapAction(ms.m, "my-map-name", uint16(0), theFellowship[0], unknownAction)
@@ -1741,7 +1741,7 @@ func TestCheckForModeChange(t *testing.T) {
 
 func TestRunWithBoundaryTestLoop(t *testing.T) {
 
-	t.Log("given the boundary test loop")
+	t.Log("given the boundary test loop in use pre-initialized elements mode")
 	{
 		t.Log("\twhen target map is empty")
 		{
@@ -1756,6 +1756,7 @@ func TestRunWithBoundaryTestLoop(t *testing.T) {
 						&runnerProperties{
 							numMaps:             numMaps,
 							numRuns:             numRuns,
+							numEntriesPerMap:    uint32(len(theFellowship)),
 							cleanMapsPriorToRun: false,
 							sleepBetweenRuns:    sleepConfigDisabled,
 						},
@@ -1764,12 +1765,14 @@ func TestRunWithBoundaryTestLoop(t *testing.T) {
 						1.0,
 						0.0,
 						1.0,
-						// Set operation chain length to length of source data for this set of tests
-						len(theFellowship),
+						// Since the operation chain is not reset by one step for a read operation, we now need at least
+						// two times the length of the data set for all the elements to be inserted in one run of the
+						// chain
+						2*len(theFellowship),
 						true,
 					)
 					ms := assembleTestMapStore(&testMapStoreBehavior{})
-					tl := assembleBoundaryTestLoop(id, testSource, &testHzClientHandler{}, ms, rc)
+					tl := assembleBoundaryTestLoop(id, testSource, true, &testHzClientHandler{}, ms, rc)
 
 					tl.run()
 
@@ -1780,11 +1783,21 @@ func TestRunWithBoundaryTestLoop(t *testing.T) {
 						t.Fatal(msg, ballotX, ms.m.setInvocations)
 					}
 
-					msg = "\t\t\t\tnumber of get invocations must be equal to number of set invocations minus one"
-					if ms.m.getInvocations == ms.m.setInvocations-1 {
+					// Because the operation chain doesn't get reset by one step after a read anymore and because
+					// we provide two times the number of elements in the source data as the length of the operation,
+					// we now have space in the operation chain for 9 modifying operations and a full 9 read operations
+					msg = "\t\t\t\tnumber of get invocations must be equal to number of set invocations"
+					if ms.m.getInvocations == ms.m.setInvocations {
 						t.Log(msg, checkMark)
 					} else {
 						t.Fatal(msg, ballotX, ms.m.getInvocations)
+					}
+
+					msg = "\t\t\t\tnumber of remove invocations must be zero"
+					if ms.m.removeInvocations == 0 {
+						t.Log(msg, checkMark)
+					} else {
+						t.Fatal(msg, ballotX, ms.m.removeInvocations)
 					}
 				}
 
@@ -1808,7 +1821,7 @@ func TestRunWithBoundaryTestLoop(t *testing.T) {
 						true,
 					)
 					ms := assembleTestMapStore(&testMapStoreBehavior{})
-					tl := assembleBoundaryTestLoop(id, testSource, &testHzClientHandler{}, ms, rc)
+					tl := assembleBoundaryTestLoop(id, testSource, true, &testHzClientHandler{}, ms, rc)
 
 					tl.run()
 
@@ -1852,6 +1865,7 @@ func TestRunWithBoundaryTestLoop(t *testing.T) {
 						&runnerProperties{
 							numMaps:             numMaps,
 							numRuns:             numRuns,
+							numEntriesPerMap:    uint32(len(theFellowship)),
 							cleanMapsPriorToRun: false,
 							sleepBetweenRuns:    sleepConfigDisabled,
 						},
@@ -1863,12 +1877,16 @@ func TestRunWithBoundaryTestLoop(t *testing.T) {
 						true,
 					)
 					ms := assembleTestMapStore(&testMapStoreBehavior{})
-					tl := assembleBoundaryTestLoop(id, testSource, &testHzClientHandler{}, ms, rc)
+					tl := assembleBoundaryTestLoop(id, testSource, true, &testHzClientHandler{}, ms, rc)
 
 					tl.run()
 
-					msg := "\t\t\t\tnumber of set invocations must be roughly equal to half the chain length"
-					if math.Abs(float64(ms.m.setInvocations-chainLength/2)) < 5 {
+					// With an action-towards-boundary-probability of 50 %, the test loop will execute inserts, reads,
+					// and removes roughly the same number of times due to the fact that after a remove on a cache of
+					// size 1, the next action has to be an insert rather than a read. Hence, the usual rule of "do a
+					// read after each modifying action" does not apply here.
+					msg := "\t\t\t\tnumber of set invocations must be roughly one third of the chain length"
+					if math.Abs(float64(ms.m.setInvocations-chainLength/3)) < 5 {
 						t.Log(msg, checkMark)
 					} else {
 						t.Fatal(msg, ballotX, ms.m.setInvocations)
@@ -1888,7 +1906,7 @@ func TestRunWithBoundaryTestLoop(t *testing.T) {
 						false,
 					)
 					ms := assembleTestMapStore(&testMapStoreBehavior{})
-					tl := assembleBoundaryTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+					tl := assembleBoundaryTestLoop(uuid.New(), testSource, true, &testHzClientHandler{}, ms, rc)
 
 					tl.run()
 
@@ -2268,7 +2286,7 @@ func TestRunOperationChain(t *testing.T) {
 				0,
 				true,
 			)
-			tl := assembleBoundaryTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+			tl := assembleBoundaryTestLoop(uuid.New(), testSource, true, &testHzClientHandler{}, ms, rc)
 
 			mc := &modeCache{}
 			ac := &actionCache{}
@@ -2344,7 +2362,7 @@ func TestRunOperationChain(t *testing.T) {
 					chainLength,
 					true,
 				)
-				tl := assembleBoundaryTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+				tl := assembleBoundaryTestLoop(uuid.New(), testSource, true, &testHzClientHandler{}, ms, rc)
 
 				mc := &modeCache{}
 				ac := &actionCache{}
@@ -2431,7 +2449,7 @@ func TestRunOperationChain(t *testing.T) {
 					chainLength,
 					true,
 				)
-				tl := assembleBoundaryTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+				tl := assembleBoundaryTestLoop(uuid.New(), testSource, true, &testHzClientHandler{}, ms, rc)
 
 				mc := &modeCache{}
 				ac := &actionCache{}
@@ -2485,7 +2503,7 @@ func TestRunOperationChain(t *testing.T) {
 				true,
 			)
 			ms := assembleTestMapStore(&testMapStoreBehavior{})
-			tl := assembleBoundaryTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+			tl := assembleBoundaryTestLoop(uuid.New(), testSource, true, &testHzClientHandler{}, ms, rc)
 
 			ts := &testSleeper{}
 			tl.s = ts
@@ -2514,7 +2532,7 @@ func TestRunOperationChain(t *testing.T) {
 				true,
 			)
 			ms := assembleTestMapStore(&testMapStoreBehavior{})
-			tl := assembleBoundaryTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+			tl := assembleBoundaryTestLoop(uuid.New(), testSource, true, &testHzClientHandler{}, ms, rc)
 
 			ts := &testSleeper{}
 			tl.s = ts
@@ -2547,7 +2565,7 @@ func TestRunOperationChain(t *testing.T) {
 				ms := assembleTestMapStore(&testMapStoreBehavior{
 					returnErrorUponSet: true,
 				})
-				tl := assembleBoundaryTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+				tl := assembleBoundaryTestLoop(uuid.New(), testSource, true, &testHzClientHandler{}, ms, rc)
 
 				ts := &testSleeper{}
 				tl.s = ts
@@ -2621,7 +2639,7 @@ func TestRunOperationChain(t *testing.T) {
 				ms := assembleTestMapStore(&testMapStoreBehavior{
 					returnErrorUponGet: true,
 				})
-				tl := assembleBoundaryTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+				tl := assembleBoundaryTestLoop(uuid.New(), testSource, true, &testHzClientHandler{}, ms, rc)
 
 				ts := &testSleeper{}
 				tl.s = ts
@@ -2699,7 +2717,7 @@ func TestRunOperationChain(t *testing.T) {
 					returnErrorUponGet:    true,
 					returnErrorUponRemove: true,
 				})
-				tl := assembleBoundaryTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+				tl := assembleBoundaryTestLoop(uuid.New(), testSource, true, &testHzClientHandler{}, ms, rc)
 
 				ts := &testSleeper{}
 				tl.s = ts
@@ -2787,7 +2805,7 @@ func TestRunWithBatchTestLoop(t *testing.T) {
 					sleepConfigDisabled,
 					sleepConfigDisabled,
 				)
-				tl := assembleBatchTestLoop(id, testSource, &testHzClientHandler{}, ms, rc)
+				tl := assembleBatchTestLoop(id, testSource, true, &testHzClientHandler{}, ms, rc)
 
 				go tl.gatherer.Listen(make(chan struct{}, 1))
 				tl.run()
@@ -2845,7 +2863,7 @@ func TestRunWithBatchTestLoop(t *testing.T) {
 					sleepConfigDisabled,
 				)
 				ms := assembleTestMapStore(&testMapStoreBehavior{})
-				tl := assembleBatchTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+				tl := assembleBatchTestLoop(uuid.New(), testSource, true, &testHzClientHandler{}, ms, rc)
 
 				go tl.gatherer.Listen(make(chan struct{}, 1))
 				tl.run()
@@ -2903,7 +2921,7 @@ func TestRunWithBatchTestLoop(t *testing.T) {
 					sleepConfigDisabled,
 				)
 				ms := assembleTestMapStore(&testMapStoreBehavior{returnErrorUponGetMap: true})
-				tl := assembleBatchTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+				tl := assembleBatchTestLoop(uuid.New(), testSource, true, &testHzClientHandler{}, ms, rc)
 
 				go tl.gatherer.Listen(make(chan struct{}, 1))
 				tl.run()
@@ -2950,7 +2968,7 @@ func TestRunWithBatchTestLoop(t *testing.T) {
 					sleepConfigDisabled,
 				)
 				ms := assembleTestMapStore(&testMapStoreBehavior{returnErrorUponGet: true})
-				tl := assembleBatchTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+				tl := assembleBatchTestLoop(uuid.New(), testSource, true, &testHzClientHandler{}, ms, rc)
 
 				go tl.gatherer.Listen(make(chan struct{}, 1))
 				tl.run()
@@ -3000,7 +3018,7 @@ func TestRunWithBatchTestLoop(t *testing.T) {
 				sleepConfigDisabled,
 				sleepConfigDisabled,
 			)
-			tl := assembleBatchTestLoop(id, testSource, &testHzClientHandler{}, ms, rc)
+			tl := assembleBatchTestLoop(id, testSource, true, &testHzClientHandler{}, ms, rc)
 
 			go tl.gatherer.Listen(make(chan struct{}, 1))
 			tl.run()
@@ -3033,7 +3051,7 @@ func TestRunWithBatchTestLoop(t *testing.T) {
 					sleepConfigDisabled,
 					scAfterActionBatch,
 				)
-				tl := assembleBatchTestLoop(uuid.New(), testSource, &testHzClientHandler{}, assembleTestMapStore(&testMapStoreBehavior{}), rc)
+				tl := assembleBatchTestLoop(uuid.New(), testSource, true, &testHzClientHandler{}, assembleTestMapStore(&testMapStoreBehavior{}), rc)
 
 				numInvocationsBetweenRuns := 0
 				numInvocationsAfterActionBatch := 0
@@ -3082,7 +3100,7 @@ func TestRunWithBatchTestLoop(t *testing.T) {
 					sleepConfigDisabled,
 					scBetweenActionsBatches,
 				)
-				tl := assembleBatchTestLoop(uuid.New(), testSource, &testHzClientHandler{}, assembleTestMapStore(&testMapStoreBehavior{}), rc)
+				tl := assembleBatchTestLoop(uuid.New(), testSource, true, &testHzClientHandler{}, assembleTestMapStore(&testMapStoreBehavior{}), rc)
 
 				numInvocationsBetweenRuns := uint32(0)
 				numInvocationsAfterActionBatch := uint32(0)
@@ -3136,7 +3154,7 @@ func TestIngestAll(t *testing.T) {
 					sleepConfigDisabled,
 					sleepConfigDisabled,
 				)
-				tl := assembleBatchTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+				tl := assembleBatchTestLoop(uuid.New(), testSource, true, &testHzClientHandler{}, ms, rc)
 
 				statusRecord := map[statusKey]any{
 					statusKeyNumFailedInserts: 0,
@@ -3200,7 +3218,7 @@ func TestIngestAll(t *testing.T) {
 					sleepConfigDisabled,
 					sleepConfigDisabled,
 				)
-				tl := assembleBatchTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+				tl := assembleBatchTestLoop(uuid.New(), testSource, true, &testHzClientHandler{}, ms, rc)
 				populateTestHzMapStore(defaultTestMapName, defaultTestMapNumber, &ms)
 
 				statusRecord := map[statusKey]any{
@@ -3260,7 +3278,7 @@ func TestIngestAll(t *testing.T) {
 					sleepConfigDisabled,
 					sleepConfigDisabled,
 				)
-				tl := assembleBatchTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+				tl := assembleBatchTestLoop(uuid.New(), testSource, true, &testHzClientHandler{}, ms, rc)
 
 				go tl.gatherer.Listen(make(chan struct{}, 1))
 				err := tl.ingestAll(ms.m, "awesome-map", uint16(0))
@@ -3319,7 +3337,7 @@ func TestIngestAll(t *testing.T) {
 					sleepConfigDisabled,
 					sleepConfigDisabled,
 				)
-				tl := assembleBatchTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+				tl := assembleBatchTestLoop(uuid.New(), testSource, true, &testHzClientHandler{}, ms, rc)
 
 				go tl.gatherer.Listen(make(chan struct{}, 1))
 				err := tl.ingestAll(ms.m, "awesome-map", uint16(0))
@@ -3360,7 +3378,7 @@ func TestIngestAll(t *testing.T) {
 					},
 					sleepConfigDisabled,
 				)
-				tl := assembleBatchTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+				tl := assembleBatchTestLoop(uuid.New(), testSource, true, &testHzClientHandler{}, ms, rc)
 				s := &testSleeper{}
 				tl.s = s
 
@@ -3401,7 +3419,7 @@ func TestIngestAll(t *testing.T) {
 					sleepConfigDisabled,
 					sleepConfigDisabled,
 				)
-				tl := assembleBatchTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+				tl := assembleBatchTestLoop(uuid.New(), testSource, true, &testHzClientHandler{}, ms, rc)
 
 				err := tl.ingestAll(ms.m, "awesome-map", uint16(0))
 
@@ -3449,7 +3467,7 @@ func TestReadAll(t *testing.T) {
 				sleepConfigDisabled,
 				sleepConfigDisabled,
 			)
-			tl := assembleBatchTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+			tl := assembleBatchTestLoop(uuid.New(), testSource, true, &testHzClientHandler{}, ms, rc)
 			populateTestHzMapStore(defaultTestMapName, defaultTestMapNumber, &ms)
 
 			go tl.gatherer.Listen(make(chan struct{}, 1))
@@ -3498,7 +3516,7 @@ func TestReadAll(t *testing.T) {
 				sleepConfigDisabled,
 				sleepConfigDisabled,
 			)
-			tl := assembleBatchTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+			tl := assembleBatchTestLoop(uuid.New(), testSource, true, &testHzClientHandler{}, ms, rc)
 
 			go tl.gatherer.Listen(make(chan struct{}, 1))
 			err := tl.readAll(ms.m, testMapBaseName, 0)
@@ -3535,7 +3553,7 @@ func TestReadAll(t *testing.T) {
 				sleepConfigDisabled,
 				sleepConfigDisabled,
 			)
-			tl := assembleBatchTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+			tl := assembleBatchTestLoop(uuid.New(), testSource, true, &testHzClientHandler{}, ms, rc)
 
 			ms.m.data.Store(assembleMapKey("awesome-map", 0, "legolas"), nil)
 
@@ -3584,7 +3602,7 @@ func TestReadAll(t *testing.T) {
 				},
 				sleepConfigDisabled,
 			)
-			tl := assembleBatchTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+			tl := assembleBatchTestLoop(uuid.New(), testSource, true, &testHzClientHandler{}, ms, rc)
 			populateTestHzMapStore(defaultTestMapName, defaultTestMapNumber, &ms)
 
 			s := &testSleeper{}
@@ -3628,7 +3646,7 @@ func TestRemoveSome(t *testing.T) {
 				sleepConfigDisabled,
 				sleepConfigDisabled,
 			)
-			tl := assembleBatchTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+			tl := assembleBatchTestLoop(uuid.New(), testSource, true, &testHzClientHandler{}, ms, rc)
 
 			populateTestHzMapStore(defaultTestMapName, defaultTestMapNumber, &ms)
 
@@ -3668,7 +3686,7 @@ func TestRemoveSome(t *testing.T) {
 				sleepConfigDisabled,
 				sleepConfigDisabled,
 			)
-			tl := assembleBatchTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+			tl := assembleBatchTestLoop(uuid.New(), testSource, true, &testHzClientHandler{}, ms, rc)
 
 			populateTestHzMapStore(defaultTestMapName, defaultTestMapNumber, &ms)
 
@@ -3707,7 +3725,7 @@ func TestRemoveSome(t *testing.T) {
 				},
 				sleepConfigDisabled,
 			)
-			tl := assembleBatchTestLoop(uuid.New(), testSource, &testHzClientHandler{}, ms, rc)
+			tl := assembleBatchTestLoop(uuid.New(), testSource, true, &testHzClientHandler{}, ms, rc)
 			populateTestHzMapStore(defaultTestMapName, defaultTestMapNumber, &ms)
 
 			s := &testSleeper{}
@@ -3838,7 +3856,7 @@ func assembleBoundaryTestLoopForBenchmark(id uuid.UUID, source string, numElemen
 		elements[i] = fmt.Sprintf("%d", i)
 	}
 
-	tle := assembleTestLoopExecution(id, source, elements, rc, ch, ms)
+	tle := assembleTestLoopExecution(id, source, elements, true, rc, ch, ms)
 	tl := boundaryTestLoop[string]{}
 	tl.init(&tle, &defaultSleeper{}, status.NewGatherer())
 
@@ -3846,18 +3864,18 @@ func assembleBoundaryTestLoopForBenchmark(id uuid.UUID, source string, numElemen
 
 }
 
-func assembleBoundaryTestLoop(id uuid.UUID, source string, ch hazelcastwrapper.HzClientHandler, ms hazelcastwrapper.MapStore, rc *runnerConfig) boundaryTestLoop[string] {
+func assembleBoundaryTestLoop(id uuid.UUID, source string, usePreInitializedElements bool, ch hazelcastwrapper.HzClientHandler, ms hazelcastwrapper.MapStore, rc *runnerConfig) boundaryTestLoop[string] {
 
-	tle := assembleTestLoopExecution(id, source, theFellowship, rc, ch, ms)
+	tle := assembleTestLoopExecution(id, source, theFellowship, usePreInitializedElements, rc, ch, ms)
 	tl := boundaryTestLoop[string]{}
 	tl.init(&tle, &defaultSleeper{}, status.NewGatherer())
 
 	return tl
 }
 
-func assembleBatchTestLoop(id uuid.UUID, source string, ch hazelcastwrapper.HzClientHandler, ms hazelcastwrapper.MapStore, rc *runnerConfig) batchTestLoop[string] {
+func assembleBatchTestLoop(id uuid.UUID, source string, usePreInitializedElements bool, ch hazelcastwrapper.HzClientHandler, ms hazelcastwrapper.MapStore, rc *runnerConfig) batchTestLoop[string] {
 
-	tle := assembleTestLoopExecution(id, source, theFellowship, rc, ch, ms)
+	tle := assembleTestLoopExecution(id, source, theFellowship, usePreInitializedElements, rc, ch, ms)
 	tl := batchTestLoop[string]{}
 	tl.init(&tle, &defaultSleeper{}, status.NewGatherer())
 
@@ -3865,18 +3883,19 @@ func assembleBatchTestLoop(id uuid.UUID, source string, ch hazelcastwrapper.HzCl
 
 }
 
-func assembleTestLoopExecution(id uuid.UUID, source string, elements []string, rc *runnerConfig, ch hazelcastwrapper.HzClientHandler, ms hazelcastwrapper.MapStore) testLoopExecution[string] {
+func assembleTestLoopExecution(id uuid.UUID, source string, elements []string, usePreInitializedElements bool, rc *runnerConfig, ch hazelcastwrapper.HzClientHandler, ms hazelcastwrapper.MapStore) testLoopExecution[string] {
 
 	return testLoopExecution[string]{
-		id:                   id,
-		source:               source,
-		hzClientHandler:      ch,
-		hzMapStore:           ms,
-		runnerConfig:         rc,
-		elements:             elements,
-		ctx:                  nil,
-		getElementID:         fellowshipMemberName,
-		getOrAssemblePayload: returnFellowshipMemberName,
+		id:                        id,
+		source:                    source,
+		hzClientHandler:           ch,
+		hzMapStore:                ms,
+		runnerConfig:              rc,
+		elements:                  elements,
+		usePreInitializedElements: usePreInitializedElements,
+		ctx:                       nil,
+		getElementID:              fellowshipMemberName,
+		getOrAssemblePayload:      returnFellowshipMemberName,
 	}
 
 }
@@ -3999,6 +4018,7 @@ func assembleBaseRunnerConfig(rp *runnerProperties) *runnerConfig {
 		enabled:                 true,
 		numMaps:                 rp.numMaps,
 		numRuns:                 rp.numRuns,
+		numEntriesPerMap:        rp.numEntriesPerMap,
 		mapBaseName:             "test",
 		useMapPrefix:            true,
 		mapPrefix:               "ht_",

--- a/maps/testloop_test.go
+++ b/maps/testloop_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/uuid"
 	"hazeltest/client"
 	"hazeltest/hazelcastwrapper"
+	"hazeltest/loadsupport"
 	"hazeltest/state"
 	"hazeltest/status"
 	"math"
@@ -2351,7 +2352,15 @@ func TestRunOperationChain(t *testing.T) {
 			t.Log("\t\twhen upper boundary is 100 %, lower boundary is 0 %, and probability for action towards boundary is 100 %")
 			{
 				ms := assembleTestMapStore(&testMapStoreBehavior{})
-				chainLength := 10 * len(theFellowship)
+				/*
+					Set up chain length so the chain will run both three complete fills and three complete drains.
+					One complete fill-drain cycle takes 35 steps rather than 36 on a source data pool of 9 elements
+					because the 36th operation would be a read, but at this point, the cache is already empty,
+					so the 36th operation instead becomes the first operation of the next iteration. Thus, if we wish
+					to set up the operation chain for three complete fill-and-drain iterations without starting
+					the next iteration, the chain needs to have 3*36-3 or 12*9-3 steps.
+				*/
+				chainLength := 12*len(theFellowship) - 3
 				rc := assembleRunnerConfigForBoundaryTestLoop(
 					rpOneMapOneRunNoEvictionScDisabled,
 					sleepConfigDisabled,
@@ -2362,7 +2371,7 @@ func TestRunOperationChain(t *testing.T) {
 					chainLength,
 					true,
 				)
-				tl := assembleBoundaryTestLoop(uuid.New(), testSource, true, &testHzClientHandler{}, ms, rc)
+				tl := assembleBoundaryTestLoop(uuid.New(), testSource, false, &testHzClientHandler{}, ms, rc)
 
 				mc := &modeCache{}
 				ac := &actionCache{}
@@ -2387,42 +2396,46 @@ func TestRunOperationChain(t *testing.T) {
 				}
 
 				/*
-						Number of elements in source data: 9
-						Chain length: 90
+					Number of elements in source data: 9
+					Chain length: 105
 
-						With both upper boundary and probability for action towards boundary set to 100 % as well as
-						lower boundary set to 0 %, the operation chain will move back and forth between completely filling
-						the map, then completely erasing the map, then going back to filling, etc.
+					With both upper boundary and probability for action towards boundary set to 100 % as well as
+					lower boundary set to 0 %, the operation chain will move back and forth between completely filling
+					and draining the map by always executing state-altering operations in the corresponding "direction",
+					i.e. fill mode will only execute inserts and reads, and drain mode will only run removes and reads.
 
-						A chain length of 90 covers 10 times fully filling or fully erasing the map if the source data
-						contains 9 elements. Thus, for each kind of the two state-changing operations, we expect them
-						to be invoked 10 / 2 * 9 times --> 45 inserts and 45 removes.
+					Within this framework, the operation chain requires 35 operations for one complete fill-drain cycle
+					(35 because, as mentioned above when defining the chain length, the last read of iteration n
+					becomes the first insert of iteration n+1 because that last read would otherwise be executed
+					on an empty cache), and the operation counts accumulate as follows:
 
-						The number of reads must be equal to <number of completed full iterations on map> * len(<source data>) - <number of times a read was skipped>.
-					    A read will be skipped if one of the following is true:
-						(1) The cache is currently empty, meaning there is nothing to be read --> Happens whenever the mode changes from "drain" back to "fill" when
-					        the map's lower boundary is 0 %
-					    (2) Loop counter reached maximum --> Happens when loop counter is <chain length - 1> -- even when the last operation was a state-changing
-					        operation, the next operation, which would necessarily be a read, will not be executed anymore
-
-						This corresponds to 10 * 9 - 5 = 85 read operations.
+					Chain position (when either 9 or zero is last hit during this iteration) -> index -> operation counts
+					(start: fill)		0 	-> 	0 	-> 0 sets, 	0 gets, 0 removes
+					(result of fill) 	17 	-> 	9 	-> 9 sets, 	9 gets, 0 removes 	-- +9 of primary, +9 gets
+					(result of drain) 	34 	-> 	0 	-> 9 sets, 	17 gets, 9 removes 	-- +9 of primary, +8 gets
+					(result of fill) 	52 	-> 	9 	-> 18 sets, 26 gets, 9 removes 	-- +9 of primary, +9 gets
+					(result of drain) 	69 	-> 	0 	-> 18 sets, 34 gets, 18 removes -- +9 of primary, +8 gets
+					(result of fill) 	87 	-> 	9 	-> 27 sets, 43 gets, 18 removes -- +9 of primary, +9 gets
+					(result of drain) 	104 ->	0 	-> 27 sets, 51 gets, 27 removes -- +9 of primary, +8 gets
 				*/
+				expectedNumStateAlteringInvocations := 12 * len(theFellowship) / 4
+				expectedNumGetInvocations := 12*len(theFellowship)/2 - 3
 				msg = "\t\t\tnumber of inserts performed must be five times the number of elements in the source data"
-				if ms.m.setInvocations == 5*len(theFellowship) {
+				if ms.m.setInvocations == expectedNumStateAlteringInvocations {
 					t.Log(msg, checkMark)
 				} else {
 					t.Fatal(msg, ballotX, fmt.Sprintf("expected %d invocations, got %d", 10*len(theFellowship), ms.m.setInvocations))
 				}
 
 				msg = "\t\t\tnumber of removes performed must be five times the number of elements in the source data, too"
-				if ms.m.removeInvocations == 5*len(theFellowship) {
+				if ms.m.removeInvocations == expectedNumStateAlteringInvocations {
 					t.Log(msg, checkMark)
 				} else {
 					t.Fatal(msg, ballotX, fmt.Sprintf("expected %d invocations, got %d", 10*len(theFellowship), ms.m.removeInvocations))
 				}
 
 				msg = "\t\t\tnumber of reads performed must be ten times the number of elements in the source data minus the number of times the read had to be skipped"
-				if ms.m.getInvocations == 10*len(theFellowship)-5 {
+				if ms.m.getInvocations == expectedNumGetInvocations {
 					t.Log(msg, checkMark)
 				} else {
 					t.Fatal(msg, ballotX, fmt.Sprintf("expected %d invocations, got %d", 10*len(theFellowship)-5, ms.m.getInvocations))
@@ -2666,7 +2679,7 @@ func TestRunOperationChain(t *testing.T) {
 				if ms.m.setInvocations == operationChainLength {
 					t.Log(msg, checkMark)
 				} else {
-					t.Fatal(msg, ballotX)
+					t.Fatal(msg, ballotX, fmt.Sprintf("expected %d, got %d invocations", operationChainLength, ms.m.setInvocations))
 				}
 
 				msg = "\t\t\treads must have been retried"
@@ -3918,13 +3931,13 @@ func assembleTestLoopExecution(id uuid.UUID, source string, elements []string, u
 
 }
 
-func returnFellowshipMemberName(_ string, _ uint16, element string) (*string, error) {
+func returnFellowshipMemberName(_ string, _ uint16, element string) (*loadsupport.PayloadWrapper, error) {
 	getOrAssembleObservations.numInvocations++
 
 	if getOrAssembleBehavior.returnError {
 		return nil, getOrAssemblePayloadError
 	}
-	return &element, nil
+	return &loadsupport.PayloadWrapper{Payload: []byte(element)}, nil
 }
 
 func assembleTestMapStoreWithBoundaryMonitoring(b *testMapStoreBehavior, bm *boundaryMonitoring) testHzMapStore {

--- a/maps/testloop_test.go
+++ b/maps/testloop_test.go
@@ -227,7 +227,7 @@ func TestMapTestLoopCountersTrackerInit(t *testing.T) {
 			statusCopy := g.AssembleStatusCopy()
 
 			for _, v := range counters {
-				if ok, detail := expectedCounterValuePresent(statusCopy, v, initialCounterValue); ok {
+				if ok, detail := expectedCounterValuePresent(statusCopy, v, initialCounterValue, eq); ok {
 					t.Log(msg, checkMark, v)
 				} else {
 					t.Fatal(msg, ballotX, detail)
@@ -593,7 +593,7 @@ func TestRunWrapper(t *testing.T) {
 
 			msg = "\t\tstatus gatherer must contain initial test loop state: %s"
 			for _, v := range []statusKey{statusKeyNumFailedInserts, statusKeyNumFailedReads, statusKeyNumFailedRemoves, statusKeyNumNilReads} {
-				if ok, detail := expectedCounterValuePresent(sc, v, 0); ok {
+				if ok, detail := expectedCounterValuePresent(sc, v, 0, eq); ok {
 					t.Log(fmt.Sprintf(msg, v), checkMark)
 				} else {
 					t.Fatal(fmt.Sprintf(msg, v), ballotX, detail)
@@ -871,7 +871,7 @@ func TestExecuteMapAction(t *testing.T) {
 					waitForStatusGatheringDone(tl.gatherer)
 
 					msg = "\t\t\tstatus gatherer must indicate zero failed insert operations"
-					if ok, detail := expectedCounterValuePresent(tl.gatherer.AssembleStatusCopy(), statusKeyNumFailedInserts, 0); ok {
+					if ok, detail := expectedCounterValuePresent(tl.gatherer.AssembleStatusCopy(), statusKeyNumFailedInserts, 0, eq); ok {
 						t.Log(msg, checkMark)
 					} else {
 						t.Fatal(msg, ballotX, detail)
@@ -918,7 +918,7 @@ func TestExecuteMapAction(t *testing.T) {
 
 					msg = "\t\t\ttest loop must have informed status gatherer about error"
 					statusCopy := tl.gatherer.AssembleStatusCopy()
-					if ok, detail := expectedCounterValuePresent(statusCopy, statusKeyNumFailedInserts, 1); ok {
+					if ok, detail := expectedCounterValuePresent(statusCopy, statusKeyNumFailedInserts, 1, eq); ok {
 						t.Log(msg, checkMark)
 					} else {
 						t.Fatal(msg, ballotX, detail)
@@ -1079,7 +1079,7 @@ func TestExecuteMapAction(t *testing.T) {
 					waitForStatusGatheringDone(tl.gatherer)
 
 					msg = "\t\t\tstatus gatherer must indicate zero failed remove attempts"
-					if ok, detail := expectedCounterValuePresent(tl.gatherer.AssembleStatusCopy(), statusKeyNumFailedRemoves, 0); ok {
+					if ok, detail := expectedCounterValuePresent(tl.gatherer.AssembleStatusCopy(), statusKeyNumFailedRemoves, 0, eq); ok {
 						t.Log(msg, checkMark)
 					} else {
 						t.Fatal(msg, ballotX, detail)
@@ -1141,7 +1141,7 @@ func TestExecuteMapAction(t *testing.T) {
 				statusCopy := tl.gatherer.AssembleStatusCopy()
 				msg = "\t\t\ttest loop must have informed status gatherer about error"
 
-				if ok, detail := expectedCounterValuePresent(statusCopy, statusKeyNumFailedRemoves, 1); ok {
+				if ok, detail := expectedCounterValuePresent(statusCopy, statusKeyNumFailedRemoves, 1, eq); ok {
 					t.Log(msg, checkMark)
 				} else {
 					t.Fatal(msg, ballotX, detail)
@@ -1237,7 +1237,7 @@ func TestExecuteMapAction(t *testing.T) {
 
 				msg = "\t\t\tstatus record must inform about one nil read"
 				statusCopy := tl.gatherer.AssembleStatusCopy()
-				if ok, detail := expectedCounterValuePresent(statusCopy, statusKeyNumNilReads, 1); ok {
+				if ok, detail := expectedCounterValuePresent(statusCopy, statusKeyNumNilReads, 1, eq); ok {
 					t.Log(msg, checkMark)
 				} else {
 					t.Fatal(msg, ballotX, detail)
@@ -1290,7 +1290,7 @@ func TestExecuteMapAction(t *testing.T) {
 
 				msg = "\t\t\ttest loop must have informed status gatherer about error"
 				statusCopy := tl.gatherer.AssembleStatusCopy()
-				if ok, detail := expectedCounterValuePresent(statusCopy, statusKeyNumFailedReads, 1); ok {
+				if ok, detail := expectedCounterValuePresent(statusCopy, statusKeyNumFailedReads, 1, eq); ok {
 					t.Log(msg, checkMark)
 				} else {
 					t.Fatal(msg, ballotX, detail)
@@ -3311,7 +3311,7 @@ func TestIngestAll(t *testing.T) {
 				waitForStatusGatheringDone(tl.gatherer)
 
 				msg = "\t\tstatus gatherer must have been informed about one failed insert attempt"
-				if ok, detail := expectedCounterValuePresent(tl.gatherer.AssembleStatusCopy(), statusKeyNumFailedInserts, 1); ok {
+				if ok, detail := expectedCounterValuePresent(tl.gatherer.AssembleStatusCopy(), statusKeyNumFailedInserts, 1, eq); ok {
 					t.Log(msg, checkMark)
 				} else {
 					t.Fatal(msg, ballotX, detail)
@@ -3352,7 +3352,7 @@ func TestIngestAll(t *testing.T) {
 
 				msg = "\t\tstatus gatherer must have been informed about one failed contains key check"
 				waitForStatusGatheringDone(tl.gatherer)
-				if ok, detail := expectedCounterValuePresent(tl.gatherer.AssembleStatusCopy(), statusKeyNumFailedKeyChecks, 1); ok {
+				if ok, detail := expectedCounterValuePresent(tl.gatherer.AssembleStatusCopy(), statusKeyNumFailedKeyChecks, 1, eq); ok {
 					t.Log(msg, checkMark)
 				} else {
 					t.Fatal(msg, ballotX, detail)
@@ -3479,7 +3479,7 @@ func TestReadAll(t *testing.T) {
 			msg := "\t\tstatus gatherer must indicate zero failed operations"
 			statusCopy := tl.gatherer.AssembleStatusCopy()
 			for _, v := range counters {
-				if ok, detail := expectedCounterValuePresent(statusCopy, v, 0); ok {
+				if ok, detail := expectedCounterValuePresent(statusCopy, v, 0, eq); ok {
 					t.Log(msg, checkMark)
 				} else {
 					t.Fatal(msg, ballotX, detail)
@@ -3522,8 +3522,8 @@ func TestReadAll(t *testing.T) {
 			err := tl.readAll(ms.m, testMapBaseName, 0)
 			tl.gatherer.StopListen()
 
-			msg := "\t\terror must be returned"
-			if err != nil {
+			msg := "\t\tno error must be returned"
+			if err == nil {
 				t.Log(msg, checkMark)
 			} else {
 				t.Fatal(msg, ballotX)
@@ -3531,8 +3531,8 @@ func TestReadAll(t *testing.T) {
 
 			waitForStatusGatheringDone(tl.gatherer)
 
-			msg = "\t\tstatus gatherer must have been informed about one failed read"
-			if ok, detail := expectedCounterValuePresent(tl.gatherer.AssembleStatusCopy(), statusKeyNumFailedReads, 1); ok {
+			msg = "\t\tstatus gatherer must have been informed about at least one failed read"
+			if ok, detail := expectedCounterValuePresent(tl.gatherer.AssembleStatusCopy(), statusKeyNumFailedReads, 1, gte); ok {
 				t.Log(msg, checkMark)
 			} else {
 				t.Fatal(msg, ballotX, detail)
@@ -3561,8 +3561,8 @@ func TestReadAll(t *testing.T) {
 			err := tl.readAll(ms.m, testMapBaseName, 0)
 			tl.gatherer.StopListen()
 
-			msg := "\t\terror must be returned"
-			if err != nil {
+			msg := "\t\tno error must be returned"
+			if err == nil {
 				t.Log(msg, checkMark)
 			} else {
 				t.Fatal(msg, ballotX)
@@ -3573,14 +3573,14 @@ func TestReadAll(t *testing.T) {
 			statusCopy := tl.gatherer.AssembleStatusCopy()
 
 			msg = "\t\tstatus gatherer must indicate zero failed reads"
-			if ok, detail := expectedCounterValuePresent(statusCopy, statusKeyNumFailedReads, 0); ok {
+			if ok, detail := expectedCounterValuePresent(statusCopy, statusKeyNumFailedReads, 0, eq); ok {
 				t.Log(msg, checkMark)
 			} else {
 				t.Fatal(msg, ballotX, detail)
 			}
 
-			msg = "\t\tstatus gatherer must indicate one nil read"
-			if ok, detail := expectedCounterValuePresent(statusCopy, statusKeyNumNilReads, 1); ok {
+			msg = "\t\tstatus gatherer must indicate at least one nil read"
+			if ok, detail := expectedCounterValuePresent(statusCopy, statusKeyNumNilReads, 1, gte); ok {
 				t.Log(msg, checkMark)
 			} else {
 				t.Fatal(msg, ballotX, detail)
@@ -3694,8 +3694,8 @@ func TestRemoveSome(t *testing.T) {
 			err := tl.removeSome(ms.m, defaultTestMapName, defaultTestMapNumber)
 			tl.gatherer.StopListen()
 
-			msg := "\t\terror must be returned"
-			if err != nil {
+			msg := "\t\tno error must be returned"
+			if err == nil {
 				t.Log(msg, checkMark)
 			} else {
 				t.Fatal(msg, ballotX)
@@ -3703,8 +3703,12 @@ func TestRemoveSome(t *testing.T) {
 
 			waitForStatusGatheringDone(tl.gatherer)
 
-			msg = "\t\tstatus gatherer must have been informed about one failed remove invocation"
-			if ok, detail := expectedCounterValuePresent(tl.gatherer.AssembleStatusCopy(), statusKeyNumFailedRemoves, 1); ok {
+			msg = "\t\tstatus gatherer must have been informed about at least one failed remove operation"
+			// Since a failure to remove an element isn't treated as being severe enough to cancel the entire remove
+			// loop and there is an element of randomness in the selection of how many elements should be removed,
+			// it's not possible to tell exactly how many failed attempts we'll record -- we just know it has to be
+			// at least one.
+			if ok, detail := expectedCounterValuePresent(tl.gatherer.AssembleStatusCopy(), statusKeyNumFailedRemoves, 1, gte); ok {
 				t.Log(msg, checkMark)
 			} else {
 				t.Fatal(msg, ballotX, detail)
@@ -3760,14 +3764,28 @@ func resetGetOrAssemblePayloadTestSetup() {
 
 }
 
-func expectedCounterValuePresent(statusCopy map[string]any, expectedKey statusKey, expectedValue uint64) (bool, string) {
+type comparisonMode string
+
+const eq comparisonMode = "equals"
+const gte comparisonMode = "greaterThanOrEqualTo"
+
+func expectedCounterValuePresent(statusCopy map[string]any, expectedKey statusKey, expectedValue uint64, cMode comparisonMode) (bool, string) {
 
 	recordedValue := statusCopy[string(expectedKey)].(uint64)
 
-	if recordedValue == expectedValue {
-		return true, ""
-	} else {
+	switch cMode {
+	case eq:
+		if recordedValue == expectedValue {
+			return true, ""
+		}
 		return false, fmt.Sprintf("expected %d, got %d", expectedValue, recordedValue)
+	case gte:
+		if recordedValue >= expectedValue {
+			return true, ""
+		}
+		return false, fmt.Sprintf("expected value to be greater than or equal to %d, got %d", expectedValue, recordedValue)
+	default:
+		return false, fmt.Sprintf("test setup error: no such comparison mode: %s", cMode)
 	}
 
 }

--- a/maps/testloop_test.go
+++ b/maps/testloop_test.go
@@ -3814,13 +3814,14 @@ func assembleTestLoopExecution(id uuid.UUID, source string, elements []string, r
 
 }
 
-func returnFellowshipMemberName(_ string, _ uint16, element any) (any, error) {
+func returnFellowshipMemberName(_ string, _ uint16, element any) (*string, error) {
 	getOrAssembleObservations.numInvocations++
 
 	if getOrAssembleBehavior.returnError {
-		return "", getOrAssemblePayloadError
+		return nil, getOrAssemblePayloadError
 	}
-	return element, nil
+	s := element.(string)
+	return &s, nil
 }
 
 func assembleTestMapStoreWithBoundaryMonitoring(b *testMapStoreBehavior, bm *boundaryMonitoring) testHzMapStore {

--- a/queues/loadrunner.go
+++ b/queues/loadrunner.go
@@ -108,6 +108,7 @@ func populateLoadElements() []loadElement {
 
 	elements := make([]loadElement, numLoadEntries)
 
+	// TODO Use new mechanism for lazy initialization of fixed payload for queue load runner, too
 	randomPayload := loadsupport.GenerateRandomStringPayload(payloadSizeBytes)
 
 	for i := 0; i < numLoadEntries; i++ {

--- a/queues/loadrunner.go
+++ b/queues/loadrunner.go
@@ -25,7 +25,7 @@ type (
 		gatherer        status.Gatherer
 	}
 	loadElement struct {
-		Payload string
+		Payload *string
 	}
 )
 

--- a/queues/loadrunner.go
+++ b/queues/loadrunner.go
@@ -25,7 +25,7 @@ type (
 		gatherer        status.Gatherer
 	}
 	loadElement struct {
-		Payload *string
+		Payload []byte
 	}
 )
 
@@ -112,7 +112,7 @@ func populateLoadElements() []loadElement {
 	randomPayload := loadsupport.GenerateRandomStringPayload(payloadSizeBytes)
 
 	for i := 0; i < numLoadEntries; i++ {
-		elements[i] = loadElement{Payload: randomPayload}
+		elements[i] = loadElement{Payload: randomPayload.Payload}
 	}
 
 	return elements

--- a/resources/charts/hazelcastwithmancenter/templates/mancenter/deployment.yaml
+++ b/resources/charts/hazelcastwithmancenter/templates/mancenter/deployment.yaml
@@ -67,10 +67,10 @@ spec:
               memory: {{ .Values.mancenter.instance.resources.limits.memory }}
           env:
             - name: JAVA_OPTS
-              value: "{{ .Values.mancenter.instance.javaOpts }}{{ if .Values.mancenter.instance.enterprise.enable }} -Dhazelcast.mc.license=$(MC_LICENSE_KEY){{ end }} -XX:+UseContainerSupport"
+              value: "{{ .Values.mancenter.instance.javaOpts }}{{ if .Values.mancenter.instance.enterprise.enabled }} -Dhazelcast.mc.license=$(MC_LICENSE_KEY){{ end }} -XX:+UseContainerSupport"
             - name: MC_INIT_CMD
               value: ./bin/mc-conf.sh cluster add --lenient=true -H /data -cc /data/hazelcastmancenter/config/hazelcast-client.yaml
-            {{- if .Values.mancenter.instance.enterprise.enable }}
+            {{- if .Values.mancenter.instance.enterprise.enabled }}
             - name: MC_LICENSE_KEY
               valueFrom:
                 secretKeyRef:

--- a/resources/charts/hazelcastwithmancenter/templates/platform/statefulset.yaml
+++ b/resources/charts/hazelcastwithmancenter/templates/platform/statefulset.yaml
@@ -39,7 +39,7 @@ spec:
             name: {{ template "hazelcastplatform.fullname" . }}-config
       containers:
         - name: {{ template "hazelcastplatform.fullname" . }}
-          image: {{ if .Values.platform.cluster.members.edition.enterprise.enable }}{{ .Values.platform.cluster.members.edition.enterprise.image }}{{ else }}{{ .Values.platform.cluster.members.edition.community.image }}{{ end }}
+          image: {{ if .Values.platform.cluster.members.edition.enterprise.enabled }}{{ .Values.platform.cluster.members.edition.enterprise.image }}{{ else }}{{ .Values.platform.cluster.members.edition.community.image }}{{ end }}
           imagePullPolicy: {{ .Values.platform.cluster.members.imagePullPolicy }}
           resources:
             {{- toYaml .Values.platform.cluster.members.containerResources | nindent 12 }}
@@ -95,7 +95,7 @@ spec:
             - name: PROMETHEUS_PORT
               value: "{{ .Values.platform.cluster.members.ports.metrics }}"
             {{- end }}
-            {{- if .Values.platform.cluster.members.edition.enterprise.enable }}
+            {{- if .Values.platform.cluster.members.edition.enterprise.enabled }}
             - name: HZ_LICENSEKEY
               valueFrom:
                 secretKeyRef:

--- a/resources/charts/hazelcastwithmancenter/values.yaml
+++ b/resources/charts/hazelcastwithmancenter/values.yaml
@@ -27,7 +27,7 @@ platform:
         enterprise:
           # Whether to use the enterprise version of Hazelcast Platform. If enabled, the name of the Kubernetes Secret
           # containing the enterprise license key has to be specified, too, see below.
-          enabled: false
+          enabled: true
           # Caution: Hazelcast Platform embodies the difference between editions in the image itself. Therefore, image
           # configuration is separated here into 'enterprise.image' and 'community.image'. (In contrast to that, the
           # Hazelcast Management Center uses one image you may supply an enterprise license to, hence for the Management

--- a/resources/charts/hazelcastwithmancenter/values.yaml
+++ b/resources/charts/hazelcastwithmancenter/values.yaml
@@ -27,7 +27,7 @@ platform:
         enterprise:
           # Whether to use the enterprise version of Hazelcast Platform. If enabled, the name of the Kubernetes Secret
           # containing the enterprise license key has to be specified, too, see below.
-          enabled: true
+          enabled: false
           # Caution: Hazelcast Platform embodies the difference between editions in the image itself. Therefore, image
           # configuration is separated here into 'enterprise.image' and 'community.image'. (In contrast to that, the
           # Hazelcast Management Center uses one image you may supply an enterprise license to, hence for the Management
@@ -55,8 +55,8 @@ platform:
           memory: "20G"
       # Increase JVM's heap size if native memory is disabled.
       jvmResources:
-        xmx: 6000m
-        xms: 6000m
+        xmx: 16000m
+        xms: 16000m
       probes:
         liveness:
           enabled: true
@@ -91,7 +91,7 @@ platform:
     # so use property names that Hazelcast expects
     nativeMemory:
       # Set this to false if you run the community edition of Hazelcast
-      enabled: true
+      enabled: false
       size:
         unit: GIGABYTES
         value: 12
@@ -129,34 +129,34 @@ platform:
         max-idle-seconds: 5
         # Caution: Native memory is an enterprise-only feature -- set this to 'BINARY' if you're running
         # the community edition.
-        # in-memory-format: BINARY
-        in-memory-format: NATIVE
+        in-memory-format: BINARY
+        # in-memory-format: NATIVE
         eviction:
           eviction-policy: LRU
-          # max-size-policy: FREE_HEAP_PERCENTAGE
-          max-size-policy: FREE_NATIVE_MEMORY_PERCENTAGE
+          f: FREE_HEAP_PERCENTAGE
+          # max-size-policy: FREE_NATIVE_MEMORY_PERCENTAGE
           size: 50
       # Config for the Hazeltest maps
       ht_*:
         backup-count: 1
         # Keep entries around for ten minutes
         max-idle-seconds: 600
-        # in-memory-format: BINARY
-        in-memory-format: NATIVE
+        in-memory-format: BINARY
+        # in-memory-format: NATIVE
         eviction:
           eviction-policy: LRU
-          # max-size-policy: FREE_HEAP_PERCENTAGE
-          max-size-policy: FREE_NATIVE_MEMORY_PERCENTAGE
+          max-size-policy: FREE_HEAP_PERCENTAGE
+          # max-size-policy: FREE_NATIVE_MEMORY_PERCENTAGE
           size: 15
       htp_*:
         backup-count: 1
         max-idle-seconds: 600
-        # in-memory-format: BINARY
-        in-memory-format: NATIVE
+        in-memory-format: BINARY
+        # in-memory-format: NATIVE
         eviction:
           eviction-policy: LRU
-          # max-size-policy: FREE_HEAP_PERCENTAGE
-          max-size-policy: FREE_NATIVE_MEMORY_PERCENTAGE
+          max-size-policy: FREE_HEAP_PERCENTAGE
+          # max-size-policy: FREE_NATIVE_MEMORY_PERCENTAGE
           size: 15
         map-store:
           enabled: true

--- a/resources/charts/hazelcastwithmancenter/values.yaml
+++ b/resources/charts/hazelcastwithmancenter/values.yaml
@@ -27,7 +27,7 @@ platform:
         enterprise:
           # Whether to use the enterprise version of Hazelcast Platform. If enabled, the name of the Kubernetes Secret
           # containing the enterprise license key has to be specified, too, see below.
-          enable: true
+          enabled: false
           # Caution: Hazelcast Platform embodies the difference between editions in the image itself. Therefore, image
           # configuration is separated here into 'enterprise.image' and 'community.image'. (In contrast to that, the
           # Hazelcast Management Center uses one image you may supply an enterprise license to, hence for the Management
@@ -204,7 +204,7 @@ mancenter:
       # Whether to upgrade this Management Center instance to the enterprise version by injecting a secret into the
       # Pod. If set to 'true', then the name of the Kubernetes Secret containing the enterprise license
       # key has to be specified, too.
-      enable: false
+      enabled: false
       license:
         # The name of the Kubernetes Secret containing the license key for
         # the enterprise version of Management Center.

--- a/resources/charts/hazeltest/Chart.yaml
+++ b/resources/charts/hazeltest/Chart.yaml
@@ -6,4 +6,4 @@ type: application
 
 version: 1.3.2
 
-appVersion: "0.16.2"
+appVersion: "0.16.3"

--- a/resources/charts/hazeltest/values.yaml
+++ b/resources/charts/hazeltest/values.yaml
@@ -4,17 +4,17 @@ image:
   registry: docker.io
   organization: antsinmyey3sjohnson
   repository: hazeltest
-  tag: 0.16.2
-  digest: 4b843a1854de4e577a4bfdd6ce0972d3f0ad398f08e43313dae8aa3219bb5adf
+  tag: 0.16.3-dev7
+  digest: f577bace2857d1957dd23c57d2dd8c7e81ac00b3a9bece810a9d6236f6f7dba7
   pullPolicy: IfNotPresent
 
 resources:
   requests:
     cpu: "200m"
-    memory: "250Mi"
+    memory: "50Mi"
   limits:
     cpu: "400m"
-    memory: "500Mi"
+    memory: "100Mi"
 
 startupArgs:
   - "-config-file=/data/config/custom-config.yaml"


### PR DESCRIPTION
Introduces significant changes to how the map-related Batch Test Loop and Boundary Test Loop keep track of the payloads they have written to the Hazelcast cluster under test or read/deleted from there. This also required a small rework of how dummy payloads get created, cached, and managed.

Previously, payloads used by map runners by means of the aforementioned test loops were lazily initialized in case of variable-size payload generation mode, but eagerly so in fixed-payload generation mode. This didn't constitute a problem for load configs with a small number of map elements to be written to the Hazelcast cluster under test, but meant enormous memory consumption if the user wished to work with a large number of map elements -- pointers to the dummy payload were used, of course, but the memory required to store string pointers adds up if a large number of pointers is required (say, > 1.000.000).

In order to reduce the memory footprint in such scenarios, the mechanism in both the Batch Test Loop and Boundary Test Loop used for both the Map Pokedex Runner and the Map Load Runner for keeping track of entries stored, read, and deleted was reworked to be compatible with both eager and lazy dummy payload generation, the former still necessarily being used by the Pokedex Runner due to the nature of its data source, but the latter now being employed in both fixed-size and variable-size payload generation mode by the Load Runner.

Basically,  in the new mechanism, the test loops now only manage a couple of indices for keeping track of which entries they stored in the Hazelcast cluster or read/deleted from it, whereas the previous iteration employed in-memory data structures as a kind of local cache to mirror the remote cache represented by the map in question in the target Hazelcast cluster.

The payload generation mechanism was extended such that it now offers a uniform set of methods for callers regardless of which payload generation mode they use.